### PR TITLE
Refactor decoding methods to a decoder object

### DIFF
--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -141,6 +141,17 @@ class MessageTest < Minitest::Test
     assert_equal 1234, obj.shop_id
     assert_equal "hello world", obj.id
     assert_equal false, obj.boolean
+
+    data = ::TestMessage.encode(TestMessage.new.tap { |x|
+      x.id = "hello world2"
+      x.shop_id = 555
+      x.boolean = true
+    })
+
+    obj = ProtoBuff::TestMessage.decode data
+    assert_equal 555, obj.shop_id
+    assert_equal "hello world2", obj.id
+    assert_equal true, obj.boolean
   end
 
   def test_decode_test1


### PR DESCRIPTION
I was really hesitant to do this, but I think the code is becoming unwieldy. I pulled the "decoding" methods in to a decoder object. Allocating an object every time we want to decode a protobuf is not ideal, but I'm thinking that:

1. If we can limit it to just one object it should be fine (I think 1 object overhead for an object graph that has N objects is no big deal)
2. We might be able to turn this decoder class in to a template so we can basically just inline these methods

I think the main challenge is "embedded" objects, IOW protobuf structs that point to other protobuf structs. I want to make sure that in that case we:

1. Don't allocate a second decoder object for the child struct
2. Don't copy the string buffer

I think it's possible, I just wanted to send the code I've written so far.