### PR TITLE
Stop using `new` for allocating objects

### DIFF
--- a/lib/protobuff/codegen.rb
+++ b/lib/protobuff/codegen.rb
@@ -5,7 +5,8 @@ require "erb"
 module ProtoBuff
   class CodeGen
     PRELUDE = ERB.new(<<-ruby, trim_mode: '-')
-    obj = <%= message.name %>.new
+    obj = <%= message.name %>.allocate
+    obj.init_defaults
     index = start
 
     while true
@@ -250,6 +251,12 @@ class <%= message.name %>
   <%- for field in message.fields -%>
     @<%= field.name %> = <%= field.name %>
   <%- end -%>
+  <%- end -%>
+  end
+
+  def init_defaults
+  <%- for field in message.fields -%>
+    @<%= field.name %> = <%= default_for(field) %>
   <%- end -%>
   end
 end


### PR DESCRIPTION
When we're parsing protobuf messages, we know that all objects need to start out with all of their members filled with "default" values. Before this commit, we would rely on the "default parameters" of the `initialize` method to set those values.

For example, the `initialize` method we would generate looks like this:

```ruby
class Foo
  def initialize(foo: "", bar: true)
    @foo = foo
    @bar = bar
  end
end
```

YJIT calls in to Class#new, but `Class#new` needs to do a bunch of stuff to set up a kwarg frame with all these default values (not to mention we have extra instructions for all of the local variable reads).

This patch adds a secondary method called `init_defaults` that just initializes the internals of the struct to their default values. `init_defaults` looks like this:

```ruby
class Foo
  def init_defaults
    @foo = ""
    @bar = true
  end
end
```

Rather than calling `Foo.new`, the parser will call:

```ruby
obj = Foo.allocate
obj.init_defaults
```

Both `allocate` and `init_defaults` are argc of 0, and the `init_defaults` doesn't need to do any local reads (it just assigns immediates to instance variables).

YJIT before:

```
Comparison:
decode upstream (53738 bytes):     7093.2 i/s
decode protobuff (53738 bytes):     1336.9 i/s - 5.31x  slower
```

YJIT after:

```
Comparison:
decode upstream (53738 bytes):     7261.3 i/s
decode protobuff (53738 bytes):     1523.3 i/s - 4.77x  slower
```