### PR TITLE
make sure string literals are frozen in generated code

### DIFF
--- a/lib/protobuff/codegen.rb
+++ b/lib/protobuff/codegen.rb
@@ -280,7 +280,8 @@ ruby
     end
 
     def to_ruby
-      head = if @ast.package
+      head = "# frozen_string_literal: true\n"
+      head += if @ast.package
         "module " + @ast.package.split('_').map(&:capitalize).join + "\n"
       else
         ""

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -185,4 +185,9 @@ class MessageTest < ProtoBuff::Test
 
     assert_equal expected.a, actual.a
   end
+
+  def test_default_string_is_frozen
+    obj = TestString.new
+    assert_predicate obj.a, :frozen?
+  end
 end


### PR DESCRIPTION
down to:

```
Comparison:
decode upstream (53738 bytes):     7259.4 i/s
decode protobuff (53738 bytes):     1645.9 i/s - 4.41x  slower
```