### PR TITLE
Add support for type 'bytes'

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -430,6 +430,13 @@ module ProtoBoeuf
       index += value
       ruby
 
+      PULL_BYTES = ERB.new(<<-ruby, trim_mode: '-')
+      value = <%= pull_varint %>
+
+      <%= dest %> <%= operator %> buff.byteslice(index, value).force_encoding(Encoding::ASCII_8BIT)
+      index += value
+      ruby
+
       PULL_SINT32 = ERB.new(<<-ruby, trim_mode: '-')
       ## PULL SINT32
       value = <%= pull_varint %>
@@ -582,7 +589,7 @@ ruby
         else
           case type
           when "string" then pull_string(dest, operator)
-          when "bytes" then pull_string(dest, operator)
+          when "bytes" then pull_bytes(dest, operator)
           when "uint64" then pull_uint64(dest, operator)
           when "int64" then pull_int64(dest, operator)
           when "int32" then pull_int32(dest, operator)
@@ -675,7 +682,15 @@ ruby
       alias :pull_sint64 :pull_sint32
 
       def pull_string(dest, operator)
-        PULL_STRING.result(binding)
+        "        ## PULL_STRING\n" +
+          PULL_STRING.result(binding) +
+          "        ## END PULL_STRING\n"
+      end
+
+      def pull_bytes(dest, operator)
+        "        ## PULL_BYTES\n" +
+          PULL_BYTES.result(binding) +
+          "        ## END PULL_BYTES\n"
       end
 
       def pull_uint64(dest, operator)

--- a/lib/protoboeuf/parser.rb
+++ b/lib/protoboeuf/parser.rb
@@ -151,9 +151,7 @@ module ProtoBoeuf
         LEN
       else
         case type
-        when "string"
-          LEN
-        when "bytes"
+        when "string", "bytes"
           LEN
         when "int64", "int32", "uint64", "bool", "sint32", "sint64", "uint32"
           VARINT

--- a/test/fixtures/test.proto
+++ b/test/fixtures/test.proto
@@ -26,10 +26,15 @@ message TestString {
   optional string a = 1;
 }
 
+message TestBytes {
+  optional string a = 1;
+}
+
 message TestMessage {
   string id = 1;
   uint64 shop_id = 2; // Comment after field
   bool boolean = 3;
+  bytes uuid = 4;
 }
 
 /*

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -89,23 +89,27 @@ class MessageTest < ProtoBoeuf::Test
       x.id = "hello world"
       x.shop_id = 1234
       x.boolean = false
+      x.uuid = ["123e4567-e89b-12d3-a456-426614174000".delete("-")].pack("H*")
     })
 
     obj = TestMessage.decode data
     assert_equal 1234, obj.shop_id
     assert_equal "hello world", obj.id
     assert_equal false, obj.boolean
+    assert_equal "\x12>Eg\xE8\x9B\x12\xD3\xA4VBf\x14\x17@\x00".b, obj.uuid
 
     data = ::TestMessage.encode(::TestMessage.new.tap { |x|
       x.id = "hello world2"
       x.shop_id = 555
       x.boolean = true
+      x.uuid = ["345e4567-e89b-12d3-a456-426614174000".delete("-")].pack("H*")
     })
 
     obj = TestMessage.decode data
     assert_equal 555, obj.shop_id
     assert_equal "hello world2", obj.id
     assert_equal true, obj.boolean
+    assert_equal "4^Eg\xE8\x9B\x12\xD3\xA4VBf\x14\x17@\x00".b, obj.uuid
   end
 
   def test_decode_test1
@@ -134,6 +138,12 @@ class MessageTest < ProtoBoeuf::Test
     data = ::TestString.encode(::TestString.new.tap { |x| x.a = "foo" })
     obj = TestString.decode data
     assert_equal "foo", obj.a
+  end
+
+  def test_decode_testbytes
+    data = ::TestBytes.encode(::TestBytes.new.tap { |x| x.a = "\x00\x01\x02\x03\x04".b })
+    obj = TestBytes.decode data
+    assert_equal "\x00\x01\x02\x03\x04".b, obj.a
   end
 
   def test_default_values_repeated_field
@@ -184,6 +194,13 @@ class MessageTest < ProtoBoeuf::Test
   def test_default_string
     expected = ::TestString.new
     actual = TestString.new
+
+    assert_equal expected.a, actual.a
+  end
+
+  def test_default_Bytes
+    expected = ::TestBytes.new
+    actual = TestBytes.new
 
     assert_equal expected.a, actual.a
   end


### PR DESCRIPTION
This adds support for `bytes` which are a variation of string. Technically it should be coerced into an ASCII_8BIT string instead of a UTF8 string