### PR TITLE
Benchmark generated data size

### DIFF
--- a/bench/benchmark.rb
+++ b/bench/benchmark.rb
@@ -49,10 +49,10 @@ def gen_fake_field_val(type_map, field)
   when "bool"
     rand < 0.5
   when "bytes"
-    Array.new(255).map { rand(255).chr("BINARY") }.join
+    (1..rand(255)).map { rand(255).chr("BINARY") }.join
   when "string"
     # TODO: better random strings with variable lengths
-    Array.new(255).map { gen_fake_unicode }.join
+    (1..rand(255)).map { gen_fake_unicode }.join
   when "uint32"
     # TODO: we may want a normal or poisson distribution?
     # We don't care about negative integers for this benchmark (rarely used)


### PR DESCRIPTION
This PR adjusts the benchmark generated fields to produce messages that exercise the range of values.

Interestingly, the larger that string and bytes fields become the wider the performance delta becomes between this and protoc