### PR TITLE
Add first "known type" implementation

### DIFF
--- a/lib/protoboeuf/parser.rb
+++ b/lib/protoboeuf/parser.rb
@@ -50,6 +50,10 @@ module ProtoBoeuf
     def accept(viz)
       viz.visit_unit self
     end
+
+    def to_ruby
+      ProtoBoeuf::CodeGen.new(self).to_ruby
+    end
   end
 
   class Option < Struct.new(:name, :value, :pos)

--- a/lib/protoboeuf/protobuf/uint64value.proto
+++ b/lib/protoboeuf/protobuf/uint64value.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package proto_boeuf.protobuf;
+
+message UInt64Value {
+  uint64 value = 1;
+}

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module ProtoBoeuf
+  module Protobuf
+
+    class UInt64Value
+      def self.decode(buff)
+        buff = buff.dup
+        buff.force_encoding("UTF-8")
+        allocate.decode_from(buff, 0, buff.bytesize)
+      end
+
+      # required field readers
+      attr_accessor :value
+
+      # enum readers
+
+      # enum writers
+
+      def initialize(value: 0)
+        @value = value
+      end
+
+      def decode_from(buff, index, len)
+
+          @value = 0
+
+                tag = buff.getbyte(index)
+            index += 1
+
+
+        while true
+          if tag == 0x8
+                    ## PULL_UINT64
+            @value =       if (byte0 = buff.getbyte(index)) < 0x80
+            index += 1
+            byte0
+          else
+            if (byte1 = buff.getbyte(index + 1)) < 0x80
+              index += 2
+              (byte1 << 7) | (byte0 & 0x7F)
+            else
+              if (byte2 = buff.getbyte(index + 2)) < 0x80
+                index += 3
+                (byte2 << 14) |
+                        ((byte1 & 0x7F) << 7) |
+                        (byte0 & 0x7F)
+              else
+                if (byte3 = buff.getbyte(index + 3)) < 0x80
+                  index += 4
+                  (byte3 << 21) |
+                          ((byte2 & 0x7F) << 14) |
+                          ((byte1 & 0x7F) << 7) |
+                          (byte0 & 0x7F)
+                else
+                  if (byte4 = buff.getbyte(index + 4)) < 0x80
+                    index += 5
+                    (byte4 << 28) |
+                            ((byte3 & 0x7F) << 21) |
+                            ((byte2 & 0x7F) << 14) |
+                            ((byte1 & 0x7F) << 7) |
+                            (byte0 & 0x7F)
+                  else
+                    if (byte5 = buff.getbyte(index + 5)) < 0x80
+                      index += 6
+                      (byte5 << 35) |
+                              ((byte4 & 0x7F) << 28) |
+                              ((byte3 & 0x7F) << 21) |
+                              ((byte2 & 0x7F) << 14) |
+                              ((byte1 & 0x7F) << 7) |
+                              (byte0 & 0x7F)
+                    else
+                      if (byte6 = buff.getbyte(index + 6)) < 0x80
+                        index += 7
+                        (byte6 << 42) |
+                                ((byte5 & 0x7F) << 35) |
+                                ((byte4 & 0x7F) << 28) |
+                                ((byte3 & 0x7F) << 21) |
+                                ((byte2 & 0x7F) << 14) |
+                                ((byte1 & 0x7F) << 7) |
+                                (byte0 & 0x7F)
+                      else
+                        if (byte7 = buff.getbyte(index + 7)) < 0x80
+                          index += 8
+                          (byte7 << 49) |
+                                  ((byte6 & 0x7F) << 42) |
+                                  ((byte5 & 0x7F) << 35) |
+                                  ((byte4 & 0x7F) << 28) |
+                                  ((byte3 & 0x7F) << 21) |
+                                  ((byte2 & 0x7F) << 14) |
+                                  ((byte1 & 0x7F) << 7) |
+                                  (byte0 & 0x7F)
+                        else
+                          if (byte8 = buff.getbyte(index + 8)) < 0x80
+                            index += 9
+                            (byte8 << 56) |
+                                    ((byte7 & 0x7F) << 49) |
+                                    ((byte6 & 0x7F) << 42) |
+                                    ((byte5 & 0x7F) << 35) |
+                                    ((byte4 & 0x7F) << 28) |
+                                    ((byte3 & 0x7F) << 21) |
+                                    ((byte2 & 0x7F) << 14) |
+                                    ((byte1 & 0x7F) << 7) |
+                                    (byte0 & 0x7F)
+                          else
+                            if (byte9 = buff.getbyte(index + 9)) < 0x80
+                              index += 10
+
+                              (byte9 << 63) |
+                                      ((byte8 & 0x7F) << 56) |
+                                      ((byte7 & 0x7F) << 49) |
+                                      ((byte6 & 0x7F) << 42) |
+                                      ((byte5 & 0x7F) << 35) |
+                                      ((byte4 & 0x7F) << 28) |
+                                      ((byte3 & 0x7F) << 21) |
+                                      ((byte2 & 0x7F) << 14) |
+                                      ((byte1 & 0x7F) << 7) |
+                                      (byte0 & 0x7F)
+                            else
+                              raise "integer decoding error"
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+
+            ## END PULL_UINT64
+
+
+            return self if index >= len
+                    tag = buff.getbyte(index)
+            index += 1
+
+          end
+
+          return self if index >= len
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/test.proto
+++ b/test/fixtures/test.proto
@@ -210,3 +210,7 @@ message HasSubEnum {
 
   Thing a = 1;
 }
+
+message HasKnownValue {
+  google.protobuf.UInt64Value id = 1;
+}

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,5 @@
+ENV["MT_NO_PLUGINS"] = "1"
+
 require "minitest/autorun"
 require "minitest/color"
 require "proto/test/fixtures/test_pb"

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -471,4 +471,14 @@ class MessageTest < ProtoBoeuf::Test
 
     assert_equal expected.a, actual.a
   end
+
+  def test_translate_known_types_in_proto
+    data = ::HasKnownValue.encode(::HasKnownValue.new.tap { |x|
+      x.id = Google::Protobuf::UInt64Value.new(value: 123456)
+    })
+
+    instance = HasKnownValue.decode(data)
+    assert_kind_of ::ProtoBoeuf::Protobuf::UInt64Value, instance.id
+    assert_equal 123456, instance.id.value
+  end
 end


### PR DESCRIPTION
This adds the first "known type" implementation, uint64value.  We'll start adding other types later.

For now, generated protobuf code will require the known type from the protoboeuf gem.  We should add a flag to support generating "stand alone" `.rb` files (which should be easy enough since we have the source .proto files)