### PR TITLE
Add encoding for uint64 fields

### DIFF
--- a/lib/protoboeuf/parser.rb
+++ b/lib/protoboeuf/parser.rb
@@ -145,6 +145,10 @@ module ProtoBoeuf
       end
     end
 
+    def scalar?
+      SCALAR_TYPES.include?(type)
+    end
+
     VARINT = 0
     I64 = 1
     LEN = 2

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -10,6 +10,9 @@ module ProtoBoeuf
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 
+      def self.encode(obj)
+        obj._encode
+      end
       # required field readers
       attr_accessor :value
 
@@ -142,6 +145,20 @@ module ProtoBoeuf
           raise NotImplementedError
         end
       end
+    def _encode
+      buff = ''.b
+            ## encode the tag
+            buff << 0x08
+            val = @value
+            while val > 0
+              byte = val & 0x7F
+              val >>= 7
+              byte |= 0x80 if val > 0
+              buff << byte
+            end
+
+      buff
+    end
     end
   end
 end

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -481,4 +481,26 @@ class MessageTest < ProtoBoeuf::Test
     assert_kind_of ::ProtoBoeuf::Protobuf::UInt64Value, instance.id
     assert_equal 123456, instance.id.value
   end
+
+  def test_encode_uint64
+    code = ProtoBoeuf.parse_string <<-eoboeuf
+syntax = "proto3";
+
+message UInt64Value {
+  uint64 value = 1;
+}
+    eoboeuf
+
+    m = Module.new { class_eval code.to_ruby }
+
+    # Should fit in one byte
+    actual = m::UInt64Value.encode m::UInt64Value.new(value: 12)
+    expected = ::Google::Protobuf::UInt64Value.encode(::Google::Protobuf::UInt64Value.new(value: 12))
+    assert_equal expected, actual
+
+    # Use more bytes
+    actual = m::UInt64Value.encode m::UInt64Value.new(value: 0xFF)
+    expected = ::Google::Protobuf::UInt64Value.encode(::Google::Protobuf::UInt64Value.new(value: 0xFF))
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
First stab at encoding support.  Only supports uint64 fields.