### PR TITLE
Use Encoding object rather than a string

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -154,7 +154,7 @@ module ProtoBoeuf
         <<-eoruby
   def self.decode(buff)
     buff = buff.dup
-    buff.force_encoding("UTF-8")
+    buff.force_encoding(Encoding::UTF_8)
     allocate.decode_from(buff, 0, buff.bytesize)
   end
 

--- a/lib/protoboeuf/protobuf/boolvalue.rb
+++ b/lib/protoboeuf/protobuf/boolvalue.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class BoolValue
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class BytesValue
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class DoubleValue
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class FloatValue
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/int32value.rb
+++ b/lib/protoboeuf/protobuf/int32value.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class Int32Value
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/int64value.rb
+++ b/lib/protoboeuf/protobuf/int64value.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class Int64Value
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class StringValue
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/timestamp.rb
+++ b/lib/protoboeuf/protobuf/timestamp.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class Timestamp
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/uint32value.rb
+++ b/lib/protoboeuf/protobuf/uint32value.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class UInt32Value
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -6,7 +6,7 @@ module ProtoBoeuf
     class UInt64Value
       def self.decode(buff)
         buff = buff.dup
-        buff.force_encoding("UTF-8")
+        buff.force_encoding(Encoding::UTF_8)
         allocate.decode_from(buff, 0, buff.bytesize)
       end
 


### PR DESCRIPTION
Somewhat of a personal pet peeve, but also saves Ruby from scanning the list of encoding to find the UTF-8 index. So saves a wee bit of performance.

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
Warming up --------------------------------------
            enc name     1.450M i/100ms
            Encoding     2.256M i/100ms
Calculating -------------------------------------
            enc name     21.712M (± 0.5%) i/s -    108.752M in   5.009052s
            Encoding     42.971M (± 0.8%) i/s -    216.545M in   5.039744s

Comparison:
            enc name: 21711640.5 i/s
            Encoding: 42970583.8 i/s - 1.98x  faster
```

```ruby
require 'bundler/inline'

buf = Random.bytes(500)

gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
end

Benchmark.ips do |x|
  x.report("enc name") { buf.force_encoding("UTF-8") }
  x.report("Encoding") { buf.force_encoding(Encoding::UTF_8) }
  x.compare!(order: :baseline)
end
```