### PR TITLE
Enable benchmark-ips baseline comparison

### DIFF
--- a/bench/benchmark.rb
+++ b/bench/benchmark.rb
@@ -141,14 +141,14 @@ bin_sizes = encoded_bins.map { |bin| bin.size }
 total_bin_size = bin_sizes.sum
 puts "total encoded size: #{total_bin_size} bytes"
 
-Benchmark.ips { |x|
+Benchmark.ips do |x|
   x.report("decode upstream")  { encoded_bins.each { |bin| Upstream::ParkingLot.decode bin } }
   x.report("decode protoboeuf") { encoded_bins.each { |bin| ProtoBoeuf::ParkingLot.decode bin } }
-  x.compare!
-}
+  x.compare!(order: :baseline)
+end
 
-Benchmark.ips { |x|
+Benchmark.ips do |x|
   x.report("decode and read upstream")  { encoded_bins.each { |bin| walk_ParkingLot(Upstream::ParkingLot.decode bin) } }
   x.report("decode and read protoboeuf") { encoded_bins.each { |bin| walk_ParkingLot(ProtoBoeuf::ParkingLot.decode bin) } }
-  x.compare!
-}
+  x.compare!(order: :baseline)
+end


### PR DESCRIPTION
This ensure that the first defined code block is the one all others are compared to. Makes the output much more readable in my opinion.

Before:

```
Comparison:
decode and read protoboeuf:       22.9 i/s
decode and read upstream:        5.7 i/s - 4.04x  slower
```

After:

```
Comparison:
decode and read upstream:        6.1 i/s
decode and read protoboeuf:       29.6 i/s - 4.88x  faster
```