### PR TITLE
Store enum state on `Field` instances, rather than in the parser

### DIFF
--- a/lib/protoboeuf/parser.rb
+++ b/lib/protoboeuf/parser.rb
@@ -105,7 +105,7 @@ module ProtoBoeuf
   MapType = Struct.new(:key_type, :value_type)
 
   # Qualifier is :optional, :required or :repeated
-  class Field < Struct.new(:qualifier, :type, :name, :number, :options, :pos)
+  class Field < Struct.new(:qualifier, :type, :name, :number, :options, :pos, :enum)
     def field?
       true
     end
@@ -113,6 +113,8 @@ module ProtoBoeuf
     def oneof?
       false
     end
+
+    alias :enum? :enum
 
     def map?
       MapType === type
@@ -162,6 +164,8 @@ module ProtoBoeuf
     def wire_type
       if repeated? && packed?
         LEN
+      elsif enum?
+        VARINT
       else
         case type
         when "string", "bytes"


### PR DESCRIPTION
Currently, the parser needs to check if a field type is an enum or not, for every field. This is a bit inefficient, and it is quite non-ergonomic.

Instead, if we store the `enum` state of a field on the `Field` instance, we can just check that directly, which is what this commit does.

When we initialize a `MessageCompiler` instance, we know all of the enum types, so we can use that information to set the `enum` state on the fields are of those types.