### PR TITLE
Fix `ParseError#to_s` implementation

### DIFF
--- a/lib/protoboeuf/parser.rb
+++ b/lib/protoboeuf/parser.rb
@@ -42,7 +42,7 @@ module ProtoBoeuf
     end
 
     def to_s
-      "#{@msg}@#{@pos}"
+      "#{super}@#{@pos}"
     end
   end
 


### PR DESCRIPTION
The `ParseError#to_s` implementation was not returning the correct result since it was not using the `@msg` instance variable to build the error message. However, that ivar is not set in the constructor, nor by the constructor of the superclass, so the error message was always empty.