### PR TITLE
Stop getting rate limited by GitHub Actions when installing protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
       - name: Set up Ruby


### PR DESCRIPTION
Since the `arduino/protoc` action is using the Github API to download and install the `protoc` binary, we were getting rate limited by Github Actions. This was causing the CI to fail sometimes.

As suggested by the `arduino/protoc` action documentation, we can pass a `GITHUB_TOKEN` to the action to avoid getting rate limited.

Ref: https://github.com/arduino/setup-protoc?tab=readme-ov-file#usage