### PR TITLE
Encode repeated fields

### DIFF
--- a/lib/protoboeuf/parser.rb
+++ b/lib/protoboeuf/parser.rb
@@ -156,6 +156,12 @@ module ProtoBoeuf
       SCALAR_TYPES.include?(type)
     end
 
+    def item_field
+      raise "not a repeated field" unless repeated?
+
+      @item_field ||= self.dup.tap { |f| f.qualifier = nil }
+    end
+
     VARINT = 0
     I64 = 1
     LEN = 2

--- a/test/fixtures/test.proto
+++ b/test/fixtures/test.proto
@@ -290,3 +290,9 @@ message EnumEncoder {
 
   Enum value = 1;
 }
+
+message RepeatedEncoder {
+  repeated uint32 intValues = 1;
+  repeated uint32 looseIntValues = 2 [packed = false];
+  repeated string stringValues = 3;
+}

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -634,6 +634,24 @@ message BytesValue {
     end
   end
 
+  def test_encode_repeated
+    actual = RepeatedEncoder.encode(
+      RepeatedEncoder.new(
+        intValues: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        looseIntValues: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        stringValues: ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+      )
+    )
+    expected = ::RepeatedEncoder.encode(
+      ::RepeatedEncoder.new(
+        intValues: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        looseIntValues: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        stringValues: ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+      )
+    )
+    assert_equal expected, actual
+  end
+
   def test_encode_string
     code = ProtoBoeuf.parse_string <<-eoboeuf
 syntax = "proto3";


### PR DESCRIPTION
Fixes #56 

In order to encode repeated fields, we need to iterate over the array of values and encode each one of them. However, until now, we didn't have a way to reuse the encoding logic for a single value. Moreover, packed repeated fields use length encoding, and don't emit the tag for each field over and over again.

For those reasons, I've done the following changes in this commit:

1. I've extracted the field encoding logic into a separate method, `encode_subtype`, which takes a field, an optional value and an optional tagged boolean, and passes these on to the individual field encoders. This way, we can reuse the encoding logic for a single value, by supplying the `value` argument to be something different than the default `@#{field.name}`. We can also control if the tag will be emitted or not, by passing the `tagged` argument as true or false.
2. I've added a new method `encode_tag_and_length` which is used to encode the tag and, if applicable, the length of a field. This method is used by all the other field encoders, and if the `length` field is passed an argument, the value of that argument is used as the expression that will return the length of the field.

These two changes allow us to implement the encoding of repeated fields in a very simple way, and they make each encode method simpler as well.