### PR TITLE
Speed up string encoding.

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -131,7 +131,7 @@ module ProtoBoeuf
         # FIXME: we should probably sort fields by field number
         "def _encode\n  buff = ''.b\n" +
           fields.map { |field| encode_subtype(field) }.compact.join("\n") +
-        "\n  buff\nend\n"
+          "\n  buff.force_encoding(Encoding::ASCII_8BIT)\nend\n"
       end
 
       def encode_subtype(field, value_expr = "@#{field.name}", tagged = true)
@@ -261,10 +261,10 @@ module ProtoBoeuf
       def encode_string(field, value_expr, tagged)
         # Empty string is default value, so encodes nothing
         <<~RUBY
-          val = #{value_expr}.encode(Encoding::UTF_8).b
+          val = #{value_expr}
           if val.bytesize > 0
             #{encode_tag_and_length(field, tagged, "val.bytesize")}
-            buff.concat(val)
+            buff << val
           end
         RUBY
       end

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -690,6 +690,7 @@ message StringValue {
     ["", "hello world", "foobar", "nöel", "some emoji 🎉👍❤️ and some math ∮𝛅x"].each do |s|
       actual = m::StringValue.encode m::StringValue.new(value: s)
       expected = ::Google::Protobuf::StringValue.encode(::Google::Protobuf::StringValue.new(value: s))
+      assert_equal Encoding::ASCII_8BIT, actual.encoding
       assert_equal expected, actual, "Failed during encoding of #{s.inspect}"
     end
   end


### PR DESCRIPTION
We go from 7x slower to 5.7x slower

On main:

```
ruby 3.4.0dev (2024-04-09T16:29:01Z master 0107954f25) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    10.000 i/100ms
   encode protoboeuf     1.000 i/100ms
Calculating -------------------------------------
     encode upstream    103.699 (± 1.9%) i/s -    520.000 in   5.016519s
   encode protoboeuf     14.757 (± 0.0%) i/s -     74.000 in   5.017772s

Comparison:
     encode upstream:      103.7 i/s
   encode protoboeuf:       14.8 i/s - 7.03x  slower
```

On this branch:

```
ruby 3.4.0dev (2024-04-09T16:29:01Z master 0107954f25) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream     9.000 i/100ms
   encode protoboeuf     1.000 i/100ms
Calculating -------------------------------------
     encode upstream     96.992 (± 3.1%) i/s -    486.000 in   5.014981s
   encode protoboeuf     16.808 (± 0.0%) i/s -     84.000 in   5.001598s

Comparison:
     encode upstream:       97.0 i/s
   encode protoboeuf:       16.8 i/s - 5.77x  slower
```