### PR TITLE
Fix decoding unordered fields

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -798,7 +798,6 @@ module ProtoBoeuf
             <%- end -%>
 
             return self if index >= len
-            raise NotImplementedError
           end
         end
       ERB

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -904,6 +904,9 @@ message Int32Value {
     # FIXME: this isn't yet working
     # Our decode method fails with the out of order fields encoded by protobuf
     data = ::TestOutOfOrder.encode(::TestOutOfOrder.new(a: 77, b: 88, c: 99))
-    #obj = TestOutOfOrder.decode data
+    obj = TestOutOfOrder.decode data
+    assert_equal(obj.a, 77)
+    assert_equal(obj.b, 88)
+    assert_equal(obj.c, 99)
   end
 end


### PR DESCRIPTION
Just remove the exception when decoding unordered fields.  I was pretty sure it already worked, but left a `NotImplemented` exception because we didn't have a test.  We have a test now, so just remove the exception.

Fixes #22 