### PR TITLE
Try to add sigstore proto files to rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,9 @@ require "rake/clean"
 
 BASE_DIR = File.dirname __FILE__
 proto_files = Rake::FileList[File.join(BASE_DIR, "test/fixtures/*.proto")]
+sig_proto_files = File.join(BASE_DIR, "test/fixtures/sigstore/*.proto")
+proto_files.add(sig_proto_files)
+
 rb_files = proto_files.pathmap("#{BASE_DIR}/lib/proto/test/fixtures/%n_pb.rb")
 
 BENCHMARK_UPSTREAM_PB = "bench/lib/upstream/benchmark_pb.rb"


### PR DESCRIPTION
@tenderworks I've added the sigstore proto files to the repo, but I'm not sure how to adjust the rakefile

Here I've added them to the `proto_files` list, but I'm getting the following error when running `rake test`. Advice welcome:

```
% rake test
rake aborted!
Don't know how to build task '/Users/maximecb/src/github.com/Shopify/protoboeuf/lib/proto/test/fixtures/envelope_pb.rb' (See the list of available tasks with `rake --tasks`)
Did you mean?  /Users/maximecb/src/github.com/Shopify/protoboeuf/lib/proto/test/fixtures/test_pb.rb

Tasks: TOP => test => gen_proto
(See full trace by running task with --trace)
```