### PR TITLE
Avoid allocation with the offset option for `String#unpack1`

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -919,11 +919,11 @@ module ProtoBoeuf
       end
 
       def pull_double(dest, operator)
-        "#{dest} #{operator} buff.byteslice(index, 8).unpack1('D'); index += 8"
+        "#{dest} #{operator} buff.unpack1('D', offset: index); index += 8"
       end
 
       def pull_float(dest, operator)
-        "#{dest} #{operator} buff.byteslice(index, 4).unpack1('F'); index += 4"
+        "#{dest} #{operator} buff.unpack1('F', offset: index); index += 4"
       end
 
       def pull_fixed_int64(dest, operator)

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -9,7 +9,8 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode
+        buff = obj._encode "".b
+        buff.force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value
@@ -26,7 +27,7 @@ module ProtoBoeuf
 
         while true
           if tag == 0x9
-            @value = buff.byteslice(index, 8).unpack1("D")
+            @value = buff.unpack1("D", offset: index)
             index += 8
 
             return self if index >= len
@@ -35,19 +36,22 @@ module ProtoBoeuf
           end
 
           return self if index >= len
-          raise NotImplementedError
         end
       end
-      def _encode
-        buff = "".b
+      def _encode(buff)
         val = @value
         if val != 0
-          ## encode the tag
           buff << 0x09
+
           buff << [val].pack("D")
         end
 
         buff
+      end
+      def to_h
+        result = {}
+        result["value".to_sym] = @value
+        result
       end
     end
   end

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -9,7 +9,8 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode
+        buff = obj._encode "".b
+        buff.force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value
@@ -26,7 +27,7 @@ module ProtoBoeuf
 
         while true
           if tag == 0xd
-            @value = buff.byteslice(index, 4).unpack1("F")
+            @value = buff.unpack1("F", offset: index)
             index += 4
 
             return self if index >= len
@@ -35,19 +36,22 @@ module ProtoBoeuf
           end
 
           return self if index >= len
-          raise NotImplementedError
         end
       end
-      def _encode
-        buff = "".b
+      def _encode(buff)
         val = @value
         if val != 0
-          ## encode the tag
           buff << 0x0d
+
           buff << [val].pack("F")
         end
 
         buff
+      end
+      def to_h
+        result = {}
+        result["value".to_sym] = @value
+        result
       end
     end
   end


### PR DESCRIPTION
Instead of using `byteslice` and then using `unpack1`, we can pass the
offset to `unpack1` and skip allocating a string.
This option was added in Ruby 3.1, which seems fine since CI only tests
as old as 3.2.

---

I regenerated stuff under `lib/protoboeuf/protobuf/` so it picks up the new changes. Other files might be stale too since there are more changes than what I touched.

Gives a decent boost:

Before:
```
Comparison:
     decode upstream:      109.2 i/s
   decode protoboeuf:       41.7 i/s - 2.62x  slower

Comparison:
decode and read upstream:        6.6 i/s
decode and read protoboeuf:       35.9 i/s - 5.47x  faster
```

After:
```
Comparison:
     decode upstream:      107.5 i/s
   decode protoboeuf:       44.9 i/s - 2.39x  slower

Comparison:
decode and read upstream:        6.5 i/s
decode and read protoboeuf:       37.8 i/s - 5.79x  faster
```