### PR TITLE
Encoding performance

### DIFF
--- a/lib/protoboeuf/protobuf/boolvalue.rb
+++ b/lib/protoboeuf/protobuf/boolvalue.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class BoolValue
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -1,26 +1,25 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class BytesValue
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value
 
-      def initialize(value: "")
+      def initialize(value: "".freeze)
         @value = value
       end
 
       def decode_from(buff, index, len)
-        @value = ""
+        @value = "".freeze
 
         tag = buff.getbyte(index)
         index += 1
@@ -98,10 +97,10 @@ module ProtoBoeuf
         end
       end
       def _encode(buff)
-        val = @value.b
-        if val.bytesize > 0
+        val = @value
+        if ((bs = val.bytesize) > 0)
           buff << 0x0a
-          len = val.bytesize
+          len = bs
           while len != 0
             byte = len & 0x7F
             len >>= 7
@@ -109,7 +108,7 @@ module ProtoBoeuf
             buff << byte
           end
 
-          buff.concat(val)
+          buff.concat(val.b)
         end
 
         buff

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class DoubleValue
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class FloatValue
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value

--- a/lib/protoboeuf/protobuf/int32value.rb
+++ b/lib/protoboeuf/protobuf/int32value.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class Int32Value
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value

--- a/lib/protoboeuf/protobuf/int64value.rb
+++ b/lib/protoboeuf/protobuf/int64value.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class Int64Value
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -1,26 +1,25 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class StringValue
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value
 
-      def initialize(value: "")
+      def initialize(value: "".freeze)
         @value = value
       end
 
       def decode_from(buff, index, len)
-        @value = ""
+        @value = "".freeze
 
         tag = buff.getbyte(index)
         index += 1

--- a/lib/protoboeuf/protobuf/timestamp.rb
+++ b/lib/protoboeuf/protobuf/timestamp.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class Timestamp
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :seconds, :nanos

--- a/lib/protoboeuf/protobuf/uint32value.rb
+++ b/lib/protoboeuf/protobuf/uint32value.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class UInt32Value
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -1,16 +1,15 @@
-# frozen_string_literal: true
+# encoding: ascii-8bit
+# frozen_string_literal: false
 
 module ProtoBoeuf
   module Protobuf
     class UInt64Value
       def self.decode(buff)
-        buff = buff.b
-        allocate.decode_from(buff, 0, buff.bytesize)
+        allocate.decode_from(buff.b, 0, buff.bytesize)
       end
 
       def self.encode(obj)
-        buff = obj._encode "".b
-        buff.force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
       attr_accessor :value


### PR DESCRIPTION
Default string literals to be encoded as `ascii-8bit` so we can avoid calling `.b` on string literals. Also change string literals to be mutable so we can avoid calling `.dup` on string literal buffers.

This _should_ reduce method calls, but I didn't see any change in performance. I suspect that since the time is being dominated by `String#<<` this won't make much difference until we better support `String#<<` in YJIT

cc @nirvdrum 