### PR TITLE
Remove unneeded wire_type method in CodeGen

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -877,15 +877,7 @@ module ProtoBoeuf
       end
 
       def tag_for_field(field, idx)
-        sprintf("%#02x", (idx << 3 | wire_type(field)))
-      end
-
-      def wire_type(field)
-        if field.enum?
-          ProtoBoeuf::Field::VARINT
-        else
-          field.wire_type
-        end
+        sprintf("%#02x", (idx << 3 | field.wire_type))
       end
 
       def decode_subtype(field, type, dest, operator)


### PR DESCRIPTION
Since Field#wire_type covers the enum case too