### PR TITLE
Reuse the main buffer for encoding submessages

### DIFF
--- a/lib/protoboeuf/protobuf/boolvalue.rb
+++ b/lib/protoboeuf/protobuf/boolvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: false)
         @value = value
@@ -53,11 +58,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: "".freeze)
         @value = value
@@ -113,11 +118,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: 0.0)
         @value = value
@@ -47,11 +52,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: 0.0)
         @value = value
@@ -47,11 +52,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/int32value.rb
+++ b/lib/protoboeuf/protobuf/int32value.rb
@@ -12,9 +12,23 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless -2_147_483_648 <= v && v <= 2_147_483_647
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (-2147483648..2147483647)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless -2_147_483_648 <= value && value <= 2_147_483_647
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (-2147483648..2147483647)"
+        end
         @value = value
       end
 
@@ -124,11 +138,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/int64value.rb
+++ b/lib/protoboeuf/protobuf/int64value.rb
@@ -12,9 +12,24 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless -9_223_372_036_854_775_808 <= v && v <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless -9_223_372_036_854_775_808 <= value &&
+                 value <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
         @value = value
       end
 
@@ -124,11 +139,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: "".freeze)
         @value = value
@@ -111,11 +116,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/timestamp.rb
+++ b/lib/protoboeuf/protobuf/timestamp.rb
@@ -12,10 +12,41 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :seconds, :nanos
+
+      attr_reader :seconds
+
+      attr_reader :nanos
+
+      def seconds=(v)
+        unless -9_223_372_036_854_775_808 <= v && v <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{v}) for field seconds is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
+
+        @seconds = v
+      end
+
+      def nanos=(v)
+        unless -2_147_483_648 <= v && v <= 2_147_483_647
+          raise RangeError,
+                "Value (#{v}) for field nanos is out of bounds (-2147483648..2147483647)"
+        end
+
+        @nanos = v
+      end
 
       def initialize(seconds: 0, nanos: 0)
+        unless -9_223_372_036_854_775_808 <= seconds &&
+                 seconds <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{seconds}) for field seconds is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
         @seconds = seconds
+
+        unless -2_147_483_648 <= nanos && nanos <= 2_147_483_647
+          raise RangeError,
+                "Value (#{nanos}) for field nanos is out of bounds (-2147483648..2147483647)"
+        end
         @nanos = nanos
       end
 
@@ -218,12 +249,15 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["seconds".to_sym] = @seconds
         result["nanos".to_sym] = @nanos
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/uint32value.rb
+++ b/lib/protoboeuf/protobuf/uint32value.rb
@@ -12,9 +12,23 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless 0 <= v && v <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (0..18446744073709551615)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless 0 <= value && value <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (0..18446744073709551615)"
+        end
         @value = value
       end
 
@@ -107,11 +121,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -12,9 +12,23 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless 0 <= v && v <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (0..18446744073709551615)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless 0 <= value && value <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (0..18446744073709551615)"
+        end
         @value = value
       end
 
@@ -107,11 +121,14 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value
         result
       end
+
+      private
     end
   end
 end


### PR DESCRIPTION
Previously, encoding sub-messages would allocate a new string so that the parent message could capture the length of the sub-message and encode that length.  (The encoded sub-message length must appear before the encoded sub-message itself)

This change forces sub-messages to reuse the same buffer as parent messages.  We use `String#bytesize` on the message buffer to calculate the sub-message size, then use `String#bytesplice` to insert enough bytes to encode the sub-message length

I'm not sure if we should merge this yet.

This change seems to slow down encoding.  Before this change, we're about 5x slower than the C implementation:

```
ruby 3.4.0dev (2024-07-11T19:49:14Z master 6fc83118bb) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    13.000 i/100ms
   encode protoboeuf     2.000 i/100ms
Calculating -------------------------------------
     encode upstream    136.508 (± 1.5%) i/s -    689.000 in   5.048373s
   encode protoboeuf     26.781 (± 3.7%) i/s -    134.000 in   5.010247s

Comparison:
     encode upstream:      136.5 i/s
   encode protoboeuf:       26.8 i/s - 5.10x  slower
```

With this change, we're 10x slower than the C implementation:

```
ruby 3.4.0dev (2024-07-11T19:49:14Z master 6fc83118bb) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    13.000 i/100ms
   encode protoboeuf     1.000 i/100ms
Calculating -------------------------------------
     encode upstream    134.557 (± 4.5%) i/s -    676.000 in   5.033041s
   encode protoboeuf     12.551 (±15.9%) i/s -     62.000 in   5.026741s

Comparison:
     encode upstream:      134.6 i/s
   encode protoboeuf:       12.6 i/s - 10.72x  slower
```

The interpreter is slower too.

## Things I've done to verify / troubleshoot

I've verified that this change produces the same bytes as the `main` branch.

I wanted to see if this change reduced object allocations during encoding, and it does.  With `main`, we would see about 15k allocations per test object encoding:

```
[aaron@tc-lan-adapter ~/g/yjit-bench (main)]$ ruby -I benchmarks/protoboeuf-encode/ benchmarks/protoboeuf-encode/benchmark.rb
15047
15030
16200
15745
15810
15160
15810
15875
16070
14250
15485
```

Code generated by this branch reduced it to about 9 or 10k:

```
[aaron@tc-lan-adapter ~/g/yjit-bench (main)]$ ruby -I ~/git/protobuff/bench/lib/protoboeuf benchmarks/protoboeuf-encode/benchmark.rb
9615
9591
10383
10075
10119
9679
10119
10163
10295
9063
9899
```

So we know the patch definitely had the impact of reducing object allocations.  Honestly, I'm surprised the encoder allocates this much in the first place.  I would have expected it to allocate only 1 object (the string buffer).

Here's the code I used for measuring allocations:

```ruby
# Protoboeuf decoder
require 'benchmark_pb'

Dir.chdir __dir__
fake_msg_bins = Marshal.load(File.binread('encoded_msgs.bin'))
lots = fake_msg_bins.map { |bin| ProtoBoeuf::ParkingLot.decode bin }

def allocs
  x = GC.stat(:total_allocated_objects)
  yield
  GC.stat(:total_allocated_objects) - x
end

lots.each { |lot|
  puts(allocs { ProtoBoeuf::ParkingLot.encode lot })
}
```
