### PR TITLE
Reuse the main buffer for encoding submessages

### DIFF
--- a/lib/protoboeuf/protobuf/boolvalue.rb
+++ b/lib/protoboeuf/protobuf/boolvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: false)
         @value = value
@@ -53,6 +58,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: "".freeze)
         @value = value
@@ -113,6 +118,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: 0.0)
         @value = value
@@ -47,6 +52,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: 0.0)
         @value = value
@@ -47,6 +52,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/int32value.rb
+++ b/lib/protoboeuf/protobuf/int32value.rb
@@ -12,9 +12,23 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless -2_147_483_648 <= v && v <= 2_147_483_647
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (-2147483648..2147483647)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless -2_147_483_648 <= value && value <= 2_147_483_647
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (-2147483648..2147483647)"
+        end
         @value = value
       end
 
@@ -124,6 +138,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/int64value.rb
+++ b/lib/protoboeuf/protobuf/int64value.rb
@@ -12,9 +12,24 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless -9_223_372_036_854_775_808 <= v && v <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless -9_223_372_036_854_775_808 <= value &&
+                 value <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
         @value = value
       end
 
@@ -124,6 +139,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -12,7 +12,12 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        @value = v
+      end
 
       def initialize(value: "".freeze)
         @value = value
@@ -111,6 +116,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/timestamp.rb
+++ b/lib/protoboeuf/protobuf/timestamp.rb
@@ -12,10 +12,41 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :seconds, :nanos
+
+      attr_reader :seconds
+
+      attr_reader :nanos
+
+      def seconds=(v)
+        unless -9_223_372_036_854_775_808 <= v && v <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{v}) for field seconds is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
+
+        @seconds = v
+      end
+
+      def nanos=(v)
+        unless -2_147_483_648 <= v && v <= 2_147_483_647
+          raise RangeError,
+                "Value (#{v}) for field nanos is out of bounds (-2147483648..2147483647)"
+        end
+
+        @nanos = v
+      end
 
       def initialize(seconds: 0, nanos: 0)
+        unless -9_223_372_036_854_775_808 <= seconds &&
+                 seconds <= 9_223_372_036_854_775_807
+          raise RangeError,
+                "Value (#{seconds}) for field seconds is out of bounds (-9223372036854775808..9223372036854775807)"
+        end
         @seconds = seconds
+
+        unless -2_147_483_648 <= nanos && nanos <= 2_147_483_647
+          raise RangeError,
+                "Value (#{nanos}) for field nanos is out of bounds (-2147483648..2147483647)"
+        end
         @nanos = nanos
       end
 
@@ -218,6 +249,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["seconds".to_sym] = @seconds

--- a/lib/protoboeuf/protobuf/uint32value.rb
+++ b/lib/protoboeuf/protobuf/uint32value.rb
@@ -12,9 +12,23 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless 0 <= v && v <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (0..18446744073709551615)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless 0 <= value && value <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (0..18446744073709551615)"
+        end
         @value = value
       end
 
@@ -107,6 +121,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -12,9 +12,23 @@ module ProtoBoeuf
         obj._encode("").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
-      attr_accessor :value
+
+      attr_reader :value
+
+      def value=(v)
+        unless 0 <= v && v <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{v}) for field value is out of bounds (0..18446744073709551615)"
+        end
+
+        @value = v
+      end
 
       def initialize(value: 0)
+        unless 0 <= value && value <= 18_446_744_073_709_551_615
+          raise RangeError,
+                "Value (#{value}) for field value is out of bounds (0..18446744073709551615)"
+        end
         @value = value
       end
 
@@ -107,6 +121,7 @@ module ProtoBoeuf
 
         buff
       end
+
       def to_h
         result = {}
         result["value".to_sym] = @value

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -893,34 +893,62 @@ class Test1
     if @oneof_field == :"enum_1"
       val = @enum_1
       if val
-        encoded = val._encode("")
         buff << 0x1a
-        len = encoded.bytesize
-        while len != 0
-          byte = len & 0x7F
-          len >>= 7
-          byte |= 0x80 if len > 0
-          buff << byte
+
+        # Save the buffer size before appending the submessage
+        current_len = buff.bytesize
+
+        # Write dummy bytes to store encoded length
+        buff << "1234567890".freeze
+        val._encode(buff)
+
+        # Calculate the submessage's size
+        submessage_size = buff.bytesize - current_len - 10
+
+        encoded_int_len = 0
+
+        # Overwrite the dummy bytes with the encoded length
+        while submessage_size != 0
+          byte = submessage_size & 0x7F
+          submessage_size >>= 7
+          byte |= 0x80 if submessage_size > 0
+          buff.setbyte(current_len, byte)
+          current_len += 1
+          encoded_int_len += 1
         end
 
-        buff << encoded
+        buff.slice!(current_len, 10 - encoded_int_len)
       end
     end
 
     if @oneof_field == :"enum_2"
       val = @enum_2
       if val
-        encoded = val._encode("")
         buff << 0x22
-        len = encoded.bytesize
-        while len != 0
-          byte = len & 0x7F
-          len >>= 7
-          byte |= 0x80 if len > 0
-          buff << byte
+
+        # Save the buffer size before appending the submessage
+        current_len = buff.bytesize
+
+        # Write dummy bytes to store encoded length
+        buff << "1234567890".freeze
+        val._encode(buff)
+
+        # Calculate the submessage's size
+        submessage_size = buff.bytesize - current_len - 10
+
+        encoded_int_len = 0
+
+        # Overwrite the dummy bytes with the encoded length
+        while submessage_size != 0
+          byte = submessage_size & 0x7F
+          submessage_size >>= 7
+          byte |= 0x80 if submessage_size > 0
+          buff.setbyte(current_len, byte)
+          current_len += 1
+          encoded_int_len += 1
         end
 
-        buff << encoded
+        buff.slice!(current_len, 10 - encoded_int_len)
       end
     end
 


### PR DESCRIPTION
Previously, encoding sub-messages would allocate a new string so that the parent message could capture the length of the sub-message and encode that length.  (The encoded sub-message length must appear before the encoded sub-message itself)

This change forces sub-messages to reuse the same buffer as parent messages.  We use `String#bytesize` on the message buffer to calculate the sub-message size, insert dummy bytes to store the encoded field length, overwrite the dummy bytes, then use `String#slice!` to remove any extra length bytes.

The main branch is 5.1x slower:

```
ruby 3.4.0dev (2024-07-11T19:49:14Z master 6fc83118bb) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    13.000 i/100ms
   encode protoboeuf     2.000 i/100ms
Calculating -------------------------------------
     encode upstream    140.012 (± 1.4%) i/s -    702.000 in   5.014679s
   encode protoboeuf     27.186 (± 3.7%) i/s -    136.000 in   5.007341s

Comparison:
     encode upstream:      140.0 i/s
   encode protoboeuf:       27.2 i/s - 5.15x  slower
```

With this branch, we're 4.2x slower:

```
ruby 3.4.0dev (2024-07-11T19:49:14Z master 6fc83118bb) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    14.000 i/100ms
   encode protoboeuf     3.000 i/100ms
Calculating -------------------------------------
     encode upstream    141.007 (± 0.7%) i/s -    714.000 in   5.064006s
   encode protoboeuf     33.736 (± 3.0%) i/s -    171.000 in   5.073519s

Comparison:
     encode upstream:      141.0 i/s
   encode protoboeuf:       33.7 i/s - 4.18x  slower
```

With @nirvdrum's Ruby optimizations, on this branch we're 3.6x slower:

```
ruby 3.4.0dev (2024-07-09T19:35:29Z yjit-optimize-stri.. 00cc8e4429) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    14.000 i/100ms
   encode protoboeuf     3.000 i/100ms
Calculating -------------------------------------
     encode upstream    144.419 (± 0.7%) i/s -    728.000 in   5.041405s
   encode protoboeuf     39.315 (± 2.5%) i/s -    198.000 in   5.042281s

Comparison:
     encode upstream:      144.4 i/s
   encode protoboeuf:       39.3 i/s - 3.67x  slower
```