### PR TITLE
Use String#bytesplice instead of String#slice!

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -314,7 +314,7 @@ module ProtoBoeuf
               encoded_int_len += 1
             end
 
-            buff.slice!(current_len, 10 - encoded_int_len)
+            buff.bytesplice(current_len, 10 - encoded_int_len, "".freeze)
           end
         RUBY
       end

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -917,7 +917,7 @@ class Test1
           encoded_int_len += 1
         end
 
-        buff.slice!(current_len, 10 - encoded_int_len)
+        buff.bytesplice(current_len, 10 - encoded_int_len, "".freeze)
       end
     end
 
@@ -948,7 +948,7 @@ class Test1
           encoded_int_len += 1
         end
 
-        buff.slice!(current_len, 10 - encoded_int_len)
+        buff.bytesplice(current_len, 10 - encoded_int_len, "".freeze)
       end
     end
 


### PR DESCRIPTION
String#slice! allocates and returns a substring, where bytesplice does not

Performance seems to be about the same as String#slice!

Main branch:

```
ruby 3.4.0dev (2024-07-11T19:49:14Z master 6fc83118bb) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    13.000 i/100ms
   encode protoboeuf     3.000 i/100ms
Calculating -------------------------------------
     encode upstream    138.691 (± 1.4%) i/s -    702.000 in   5.062282s
   encode protoboeuf     32.817 (± 3.0%) i/s -    165.000 in   5.032303s

Comparison:
     encode upstream:      138.7 i/s
   encode protoboeuf:       32.8 i/s - 4.23x  slower
```

This branch:

```
ruby 3.4.0dev (2024-07-11T19:49:14Z master 6fc83118bb) +YJIT [arm64-darwin23]
Warming up --------------------------------------
     encode upstream    13.000 i/100ms
   encode protoboeuf     3.000 i/100ms
Calculating -------------------------------------
     encode upstream    139.703 (± 0.7%) i/s -    702.000 in   5.025434s
   encode protoboeuf     32.458 (± 0.0%) i/s -    165.000 in   5.084305s

Comparison:
     encode upstream:      139.7 i/s
   encode protoboeuf:       32.5 i/s - 4.30x  slower
```