### PR TITLE
Set frozen_string_literal: true on generated files

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -241,7 +241,7 @@ module ProtoBoeuf
           if map.size > 0
             old_buff = buff
             map.each do |key, value|
-              buff = new_buffer = ''
+              buff = new_buffer = +''
               #{encode_subtype(field.key_field, "key", true)}
               #{encode_subtype(field.value_field, "value", true)}
               buff = old_buff
@@ -470,7 +470,7 @@ module ProtoBoeuf
 
           #{type_signature(params: {obj: message.name}, returns: "String")}
           def self.encode(obj)
-            obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+            obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
           end
         RUBY
       end
@@ -1234,7 +1234,7 @@ module ProtoBoeuf
       packages = (@ast.package || "").split(".").reject(&:empty?)
       head = "# encoding: ascii-8bit\n"
       head += "# typed: false\n" if generate_types
-      head += "# frozen_string_literal: false\n\n"
+      head += "# frozen_string_literal: true\n\n"
       head += packages.map { |m| "module " + m.split("_").map(&:capitalize).join + "\n" }.join
 
       toplevel_enums = @ast.enums.group_by(&:name)

--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -296,7 +296,7 @@ module ProtoBoeuf
             current_len = buff.bytesize
 
             # Write dummy bytes to store encoded length
-            buff << "1234567890".freeze
+            buff << "1234567890"
             val._encode(buff)
 
             # Calculate the submessage's size
@@ -314,7 +314,7 @@ module ProtoBoeuf
               encoded_int_len += 1
             end
 
-            buff.bytesplice(current_len, 10 - encoded_int_len, "".freeze)
+            buff.bytesplice(current_len, 10 - encoded_int_len, "")
           end
         RUBY
       end
@@ -922,7 +922,7 @@ module ProtoBoeuf
             else
               case field.type
               when "string", "bytes"
-                '"".freeze'
+                '""'
               when "uint64", "int32", "sint32", "uint32", "int64", "sint64", "fixed64", "fixed32", "sfixed64", "sfixed32"
                 0
               when "double", "float"

--- a/lib/protoboeuf/protobuf/boolvalue.rb
+++ b/lib/protoboeuf/protobuf/boolvalue.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -19,12 +19,12 @@ module ProtoBoeuf
         @value = v
       end
 
-      def initialize(value: "".freeze)
+      def initialize(value: "")
         @value = value
       end
 
       def decode_from(buff, index, len)
-        @value = "".freeze
+        @value = ""
 
         tag = buff.getbyte(index)
         index += 1

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/int32value.rb
+++ b/lib/protoboeuf/protobuf/int32value.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/int64value.rb
+++ b/lib/protoboeuf/protobuf/int64value.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -19,12 +19,12 @@ module ProtoBoeuf
         @value = v
       end
 
-      def initialize(value: "".freeze)
+      def initialize(value: "")
         @value = value
       end
 
       def decode_from(buff, index, len)
-        @value = "".freeze
+        @value = ""
 
         tag = buff.getbyte(index)
         index += 1

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/timestamp.rb
+++ b/lib/protoboeuf/protobuf/timestamp.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/uint32value.rb
+++ b/lib/protoboeuf/protobuf/uint32value.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -1,5 +1,5 @@
 # encoding: ascii-8bit
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module ProtoBoeuf
   module Protobuf
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
       end
       # required field readers
 

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -1,6 +1,6 @@
 # encoding: ascii-8bit
 # typed: false
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 module TestEnum
   FOO = 0
@@ -66,7 +66,7 @@ class Test1
 
   sig { params(obj: Test1).returns(String) }
   def self.encode(obj)
-    obj._encode("").force_encoding(Encoding::ASCII_8BIT)
+    obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
   end
   # required field readers
   sig { returns(Integer) }
@@ -986,7 +986,7 @@ class Test1
     if map.size > 0
       old_buff = buff
       map.each do |key, value|
-        buff = new_buffer = ""
+        buff = new_buffer = +""
         val = key
         if ((len = val.bytesize) > 0)
           buff << 0x0a

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -163,7 +163,7 @@ class Test1
     enum_2: nil,
     repeated_ints: [],
     map_field: {},
-    bytes_field: "".freeze
+    bytes_field: ""
   )
     @_bitmask = 0
 
@@ -174,7 +174,7 @@ class Test1
     @int_field = int_field
 
     if string_field == nil
-      @string_field = "".freeze
+      @string_field = ""
     else
       @_bitmask |= 0x0000000000000001
       @string_field = string_field
@@ -218,13 +218,13 @@ class Test1
     @_bitmask = 0
 
     @int_field = 0
-    @string_field = "".freeze
+    @string_field = ""
     @oneof_field = nil # oneof field
     @enum_1 = nil
     @enum_2 = nil
     @repeated_ints = []
     @map_field = {}
-    @bytes_field = "".freeze
+    @bytes_field = ""
 
     tag = buff.getbyte(index)
     index += 1
@@ -899,7 +899,7 @@ class Test1
         current_len = buff.bytesize
 
         # Write dummy bytes to store encoded length
-        buff << "1234567890".freeze
+        buff << "1234567890"
         val._encode(buff)
 
         # Calculate the submessage's size
@@ -917,7 +917,7 @@ class Test1
           encoded_int_len += 1
         end
 
-        buff.bytesplice(current_len, 10 - encoded_int_len, "".freeze)
+        buff.bytesplice(current_len, 10 - encoded_int_len, "")
       end
     end
 
@@ -930,7 +930,7 @@ class Test1
         current_len = buff.bytesize
 
         # Write dummy bytes to store encoded length
-        buff << "1234567890".freeze
+        buff << "1234567890"
         val._encode(buff)
 
         # Calculate the submessage's size
@@ -948,7 +948,7 @@ class Test1
           encoded_int_len += 1
         end
 
-        buff.bytesplice(current_len, 10 - encoded_int_len, "".freeze)
+        buff.bytesplice(current_len, 10 - encoded_int_len, "")
       end
     end
 


### PR DESCRIPTION
Alternative to #106 

Also reduces allocations by half.
Still gets to use `opt_newarray_send`.

```
before
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
    103572  (95.0%)      103572  (95.0%)     Upstream::TrunkItem#_encode
    108505  (99.5%)        4933   (4.5%)     Upstream::Vehicle#_encode
    108977 (100.0%)         465   (0.4%)     Upstream::ParkingFloor#_encode
    108993 (100.0%)          14   (0.0%)     Upstream::ParkingLot.encode
    108511  (99.5%)           6   (0.0%)     Upstream::ParkingSpace#_encode

after
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     51786  (95.0%)       51786  (95.0%)     Upstream::TrunkItem#_encode
     54253  (99.5%)        2467   (4.5%)     Upstream::Vehicle#_encode
     54494  (99.9%)         234   (0.4%)     Upstream::ParkingFloor#_encode
        11   (0.0%)          11   (0.0%)     String#+@
     54259  (99.5%)           6   (0.0%)     Upstream::ParkingSpace#_encode
```