### PR TITLE
Use little-endian directives to pack/unpack floats

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -400,7 +400,7 @@ module ProtoBoeuf
         val = #{value_expr}
         if val != 0
           #{encode_tag_and_length(field, tagged)}
-          [val].pack('D', buffer: buff)
+          [val].pack('E', buffer: buff)
         end
         eocode
       end
@@ -411,7 +411,7 @@ module ProtoBoeuf
         val = #{value_expr}
         if val != 0
           #{encode_tag_and_length(field, tagged)}
-          [val].pack('F', buffer: buff)
+          [val].pack('e', buffer: buff)
         end
         eocode
       end
@@ -996,11 +996,11 @@ module ProtoBoeuf
       end
 
       def pull_double(dest, operator)
-        "#{dest} #{operator} buff.unpack1('D', offset: index); index += 8"
+        "#{dest} #{operator} buff.unpack1('E', offset: index); index += 8"
       end
 
       def pull_float(dest, operator)
-        "#{dest} #{operator} buff.unpack1('F', offset: index); index += 4"
+        "#{dest} #{operator} buff.unpack1('e', offset: index); index += 4"
       end
 
       def pull_fixed_int64(dest, operator)

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -31,7 +31,7 @@ module ProtoBoeuf
 
         while true
           if tag == 0x9
-            @value = buff.unpack1("D", offset: index)
+            @value = buff.unpack1("E", offset: index)
             index += 8
 
             return self if index >= len
@@ -47,7 +47,7 @@ module ProtoBoeuf
         if val != 0
           buff << 0x09
 
-          [val].pack("D", buffer: buff)
+          [val].pack("E", buffer: buff)
         end
 
         buff

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -31,7 +31,7 @@ module ProtoBoeuf
 
         while true
           if tag == 0xd
-            @value = buff.unpack1("F", offset: index)
+            @value = buff.unpack1("e", offset: index)
             index += 4
 
             return self if index >= len
@@ -47,7 +47,7 @@ module ProtoBoeuf
         if val != 0
           buff << 0x0d
 
-          [val].pack("F", buffer: buff)
+          [val].pack("e", buffer: buff)
         end
 
         buff


### PR DESCRIPTION
The format spec is clear that floats are little-endian, but we were
using the directives that use the host's endianess (which could be
big-endian).
