### PR TITLE
Properly handle UTF-8 strings

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -280,7 +280,7 @@ module ProtoBoeuf
           val = #{value_expr}
           if((len = val.bytesize) > 0)
             #{encode_tag_and_length(field, tagged, "len")}
-            buff << val
+            buff << (val.ascii_only? ? val : val.b)
           end
         RUBY
       end

--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -817,7 +817,7 @@ module ProtoBoeuf
       PULL_STRING = ERB.new(<<~ERB, trim_mode: '-')
         value = <%= pull_varint %>
 
-        <%= dest %> <%= operator %> buff.byteslice(index, value)
+        <%= dest %> <%= operator %> buff.byteslice(index, value).force_encoding(Encoding::UTF_8)
         index += value
       ERB
 

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -112,7 +112,7 @@ module ProtoBoeuf
             buff << byte
           end
 
-          buff << val
+          buff << (val.ascii_only? ? val : val.b)
         end
 
         buff

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -87,7 +87,8 @@ module ProtoBoeuf
                 raise "integer decoding error"
               end
 
-            @value = buff.byteslice(index, value)
+            @value =
+              buff.byteslice(index, value).force_encoding(Encoding::UTF_8)
             index += value
 
             ## END PULL_STRING

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -888,7 +888,7 @@ class Test1
         buff << byte
       end
 
-      buff << val
+      buff << (val.ascii_only? ? val : val.b)
     end
 
     if @oneof_field == :"enum_1"
@@ -998,7 +998,7 @@ class Test1
             buff << byte
           end
 
-          buff << val
+          buff << (val.ascii_only? ? val : val.b)
         end
 
         val = value

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -350,7 +350,8 @@ class Test1
             raise "integer decoding error"
           end
 
-        @string_field = buff.byteslice(index, value)
+        @string_field =
+          buff.byteslice(index, value).force_encoding(Encoding::UTF_8)
         index += value
 
         ## END PULL_STRING
@@ -716,7 +717,7 @@ class Test1
               raise "integer decoding error"
             end
 
-          key = buff.byteslice(index, value)
+          key = buff.byteslice(index, value).force_encoding(Encoding::UTF_8)
           index += value
 
           ## END PULL_STRING

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -353,6 +353,16 @@ class MessageTest < ProtoBoeuf::Test
     assert_equal 0xCAFE, obj.b
   end
 
+  def test_decode_utf8_strings
+    string = "h€llo"
+    data = TestMessageWithOneOf.encode(TestMessageWithOneOf.new(oneof_str: string))
+    expected = ::TestMessageWithOneOf.decode(data)
+    actual = TestMessageWithOneOf.decode(data)
+
+    assert_equal expected.oneof_str, actual.oneof_str
+    assert_equal expected.oneof_str.encoding, actual.oneof_str.encoding
+  end
+
   def test_decode_repeated_messages
     data = ::RepeatedSubMessages.encode(::RepeatedSubMessages.new(ints:[
       ::TestSint64.new(sint_64: 1),


### PR DESCRIPTION
The protobuf specs do require UTF-8 and that's what `google-protobuf` returns.

Otherwise returning binary encoded string migth work in most case and cause havoc when entering non-ASCII cases.