### PR TITLE
Merge Interpreter and JIT results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 test/fixtures/*_pb.rb
 test/fixtures/typed_test.generated.rb
 bench/lib/
+bench/tmp/

--- a/Rakefile
+++ b/Rakefile
@@ -74,6 +74,11 @@ task :test => [:gen_proto, :well_known_types]
 task :default => :test
 
 task :bench => [BENCHMARK_UPSTREAM_PB, BENCHMARK_PROTOBOEUF_PB] do
+  rm_rf "bench/tmp"
+  mkdir_p "bench/tmp"
+
+  ENV["BENCH_HOLD"] = "bench/tmp/"
+
   puts "###### INTERPRETER ######"
   ruby "-I lib:bench/lib bench/benchmark.rb"
 


### PR DESCRIPTION
Using `benchmark-ips` `save!` feature we can integrate the results of two runs together and have them properly compared.

```
/opt/rubies/3.3.3/bin/ruby --yjit -I lib:bench/lib bench/benchmark.rb
total encoded size: 4669202 bytes
=== decode ===
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        upstream/jit    12.000 i/100ms
      protoboeuf/jit     5.000 i/100ms
Calculating -------------------------------------
        upstream/jit    119.255 (± 1.7%) i/s -    600.000 in   5.033000s
      protoboeuf/jit     51.050 (± 2.0%) i/s -    260.000 in   5.093866s

Comparison:
     upstream/interp:      118.6 i/s
        upstream/jit:      119.3 i/s - same-ish: difference falls within error
      protoboeuf/jit:       51.0 i/s - 2.32x  slower
   protoboeuf/interp:       12.3 i/s - 9.62x  slower

=== decode and read ===
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        upstream/jit     1.000 i/100ms
      protoboeuf/jit     4.000 i/100ms
Calculating -------------------------------------
        upstream/jit      8.080 (± 0.0%) i/s -     41.000 in   5.080061s
      protoboeuf/jit     44.526 (± 2.2%) i/s -    224.000 in   5.032944s

Comparison:
     upstream/interp:        7.2 i/s
      protoboeuf/jit:       44.5 i/s - 6.17x  faster
   protoboeuf/interp:       10.7 i/s - 1.49x  faster
        upstream/jit:        8.1 i/s - 1.12x  faster

=== encode ===
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        upstream/jit    13.000 i/100ms
      protoboeuf/jit     2.000 i/100ms
Calculating -------------------------------------
        upstream/jit    134.245 (± 2.2%) i/s -    676.000 in   5.037849s
      protoboeuf/jit     26.371 (± 0.0%) i/s -    132.000 in   5.006946s

Comparison:
     upstream/interp:      133.3 i/s
        upstream/jit:      134.2 i/s - same-ish: difference falls within error
      protoboeuf/jit:       26.4 i/s - 5.06x  slower
   protoboeuf/interp:       10.6 i/s - 12.60x  slower
```