### PR TITLE
Optimize `encode_submessage` to avoid shifting for small messages

### DIFF
--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -899,26 +899,45 @@ class Test1
         # Save the buffer size before appending the submessage
         current_len = buff.bytesize
 
-        # Write dummy bytes to store encoded length
-        buff << "1234567890"
+        # Write a single dummy byte to later store encoded length
+        buff << 42 # "*"
         val._encode(buff)
 
         # Calculate the submessage's size
-        submessage_size = buff.bytesize - current_len - 10
+        submessage_size = buff.bytesize - current_len - 1
 
-        encoded_int_len = 0
+        # Hope the size fits in one byte
+        byte = submessage_size & 0x7F
+        submessage_size >>= 7
+        byte |= 0x80 if submessage_size > 0
+        buff.setbyte(current_len, byte)
 
-        # Overwrite the dummy bytes with the encoded length
-        while submessage_size != 0
-          byte = submessage_size & 0x7F
-          submessage_size >>= 7
-          byte |= 0x80 if submessage_size > 0
-          buff.setbyte(current_len, byte)
+        # If the sub message was bigger
+        if submessage_size > 0
           current_len += 1
-          encoded_int_len += 1
+
+          # compute how much we need to shift
+          encoded_int_len = 0
+          remaining_size = submessage_size
+          while remaining_size != 0
+            remaining_size >>= 7
+            encoded_int_len += 1
+          end
+
+          # Make space in the string with dummy bytes
+          buff.bytesplice(current_len, 0, "*********", 0, encoded_int_len)
+
+          # Overwrite the dummy bytes with the encoded length
+          while submessage_size != 0
+            byte = submessage_size & 0x7F
+            submessage_size >>= 7
+            byte |= 0x80 if submessage_size > 0
+            buff.setbyte(current_len, byte)
+            current_len += 1
+          end
         end
 
-        buff.bytesplice(current_len, 10 - encoded_int_len, "")
+        buff
       end
     end
 
@@ -930,26 +949,45 @@ class Test1
         # Save the buffer size before appending the submessage
         current_len = buff.bytesize
 
-        # Write dummy bytes to store encoded length
-        buff << "1234567890"
+        # Write a single dummy byte to later store encoded length
+        buff << 42 # "*"
         val._encode(buff)
 
         # Calculate the submessage's size
-        submessage_size = buff.bytesize - current_len - 10
+        submessage_size = buff.bytesize - current_len - 1
 
-        encoded_int_len = 0
+        # Hope the size fits in one byte
+        byte = submessage_size & 0x7F
+        submessage_size >>= 7
+        byte |= 0x80 if submessage_size > 0
+        buff.setbyte(current_len, byte)
 
-        # Overwrite the dummy bytes with the encoded length
-        while submessage_size != 0
-          byte = submessage_size & 0x7F
-          submessage_size >>= 7
-          byte |= 0x80 if submessage_size > 0
-          buff.setbyte(current_len, byte)
+        # If the sub message was bigger
+        if submessage_size > 0
           current_len += 1
-          encoded_int_len += 1
+
+          # compute how much we need to shift
+          encoded_int_len = 0
+          remaining_size = submessage_size
+          while remaining_size != 0
+            remaining_size >>= 7
+            encoded_int_len += 1
+          end
+
+          # Make space in the string with dummy bytes
+          buff.bytesplice(current_len, 0, "*********", 0, encoded_int_len)
+
+          # Overwrite the dummy bytes with the encoded length
+          while submessage_size != 0
+            byte = submessage_size & 0x7F
+            submessage_size >>= 7
+            byte |= 0x80 if submessage_size > 0
+            buff.setbyte(current_len, byte)
+            current_len += 1
+          end
         end
 
-        buff.bytesplice(current_len, 10 - encoded_int_len, "")
+        buff
       end
     end
 


### PR DESCRIPTION
An optimization idea discussed with @maximecb.

Right now we reserve 10 bytes for submessages, then shift the submessage in the buffer to get rid of the unused ones.

This means we're always shifting the submessage unless it's gigantic enough to use 10 bytes to encode its length.

If instead we only reserve one byte, it allows us to not shift anything if the submessage is small enough for its length to only need one byte. So less work to do for submessages of less than 127B, as about as much work as before for bigger ones.

NB: I couldn't benchmark it yet, but my earlier profiles were showing ~10% of time spent in bytesplice, and most (not all) sub messages in the benchmark have a length that fit in one byte, so I'd expect a gain around ~8% or so.

cc @tenderworks 