### PR TITLE
Get rid of unnecessary `force_encoding` calls.

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -470,7 +470,7 @@ module ProtoBoeuf
 
           #{type_signature(params: {obj: message.name}, returns: "String")}
           def self.encode(obj)
-            obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+            obj._encode("".b)
           end
         RUBY
       end
@@ -824,7 +824,7 @@ module ProtoBoeuf
       PULL_BYTES = ERB.new(<<~ERB, trim_mode: '-')
         value = <%= pull_varint %>
 
-        <%= dest %> <%= operator %> buff.byteslice(index, value).force_encoding(Encoding::ASCII_8BIT)
+        <%= dest %> <%= operator %> buff.byteslice(index, value)
         index += value
       ERB
 

--- a/lib/protoboeuf/protobuf/boolvalue.rb
+++ b/lib/protoboeuf/protobuf/boolvalue.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 
@@ -87,8 +87,7 @@ module ProtoBoeuf
                 raise "integer decoding error"
               end
 
-            @value =
-              buff.byteslice(index, value).force_encoding(Encoding::ASCII_8BIT)
+            @value = buff.byteslice(index, value)
             index += value
 
             ## END PULL_BYTES

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/int32value.rb
+++ b/lib/protoboeuf/protobuf/int32value.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/int64value.rb
+++ b/lib/protoboeuf/protobuf/int64value.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/timestamp.rb
+++ b/lib/protoboeuf/protobuf/timestamp.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/uint32value.rb
+++ b/lib/protoboeuf/protobuf/uint32value.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -9,7 +9,7 @@ module ProtoBoeuf
       end
 
       def self.encode(obj)
-        obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+        obj._encode("".b)
       end
       # required field readers
 

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -66,7 +66,7 @@ class Test1
 
   sig { params(obj: Test1).returns(String) }
   def self.encode(obj)
-    obj._encode(+"").force_encoding(Encoding::ASCII_8BIT)
+    obj._encode("".b)
   end
   # required field readers
   sig { returns(Integer) }
@@ -844,8 +844,7 @@ class Test1
             raise "integer decoding error"
           end
 
-        @bytes_field =
-          buff.byteslice(index, value).force_encoding(Encoding::ASCII_8BIT)
+        @bytes_field = buff.byteslice(index, value)
         index += value
 
         ## END PULL_BYTES

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -719,7 +719,7 @@ message StringValue {
     ["", "hello world", "foobar", "nöel", "some emoji 🎉👍❤️ and some math ∮𝛅x"].each do |s|
       actual = m::StringValue.encode m::StringValue.new(value: s)
       expected = ::Google::Protobuf::StringValue.encode(::Google::Protobuf::StringValue.new(value: s))
-      assert_equal Encoding::ASCII_8BIT, actual.encoding
+      assert_equal Encoding::BINARY, actual.encoding
       assert_equal expected, actual, "Failed during encoding of #{s.inspect}"
     end
   end


### PR DESCRIPTION
The buffer is always ASCII-8BIT (aka BINARY) so we never need to force its encoding back to binary.

@maximecb @tenderworks 