### PR TITLE
Use protoc to generate our well known type rb files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,8 @@ rule ".rb" => ["%X.proto"] + codegen_rb_files do |t|
   unit.file.each { |f| f.package = "proto_boeuf.protobuf" }
 
   puts "writing #{t.name}"
-  File.binwrite t.name, ProtoBoeuf::CodeGen.new(unit).to_ruby
+  dest = Pathname.new(t.name).relative_path_from(File.join(BASE_DIR, "lib")).to_s.delete_suffix(".rb")
+  File.binwrite t.name, ProtoBoeuf::CodeGen.new(unit).to_ruby(dest)
 end
 
 task :well_known_types => WELL_KNOWN_PB

--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -51,23 +51,23 @@ module ProtoBoeuf
     end
 
     class MessageCompiler
-      attr_reader :generate_types
+      attr_reader :generate_types, :requires
 
       include TypeHelper
 
-      def self.result(message, toplevel_enums, generate_types:)
-        new(message, toplevel_enums, generate_types:).result
+      def self.result(message, toplevel_enums, generate_types:, requires:)
+        new(message, toplevel_enums, generate_types:, requires:).result
       end
 
       attr_reader :message, :fields, :oneof_fields
       attr_reader :optional_fields, :enum_field_types
 
-      def initialize(message, toplevel_enums, generate_types:)
+      def initialize(message, toplevel_enums, generate_types:, requires:)
         @message = message
         @optional_field_bit_lut = []
         @fields = @message.field
         @enum_field_types = toplevel_enums.merge(message.enum_type.group_by(&:name))
-        @requires = Set.new
+        @requires = requires
         @generate_types = generate_types
         @has_submessage = false
 
@@ -108,12 +108,7 @@ module ProtoBoeuf
       end
 
       def result
-        body = "class #{message.name}\n" + class_body + "end\n"
-        if @requires.empty?
-          body
-        else
-          @requires.map { |r| "require #{r.dump}" }.join("\n") + "\n\n" + body
-        end
+        "class #{message.name}\n" + class_body + "end\n"
       end
 
       private
@@ -521,7 +516,7 @@ module ProtoBoeuf
 
       def constants
         message.nested_type.reject { |x| x.options&.map_entry }.map { |x|
-          self.class.new(x, enum_field_types, generate_types:).result
+          self.class.new(x, enum_field_types, generate_types:, requires:).result
         }.join("\n")
       end
 
@@ -1350,16 +1345,19 @@ module ProtoBoeuf
     end
 
     def to_ruby
+      requires = Set.new
       @ast.file.each do |file|
         modules = resolve_modules(file)
         head = "# encoding: ascii-8bit\n"
         head += "# typed: false\n" if generate_types
         head += "# frozen_string_literal: true\n\n"
-        head += modules.map { |m| "module #{m}\n" }.join
 
         toplevel_enums = file.enum_type.group_by(&:name)
         body = file.enum_type.map { |enum| EnumCompiler.result(enum, generate_types:) }.join + "\n"
-        body += file.message_type.map { |message| MessageCompiler.result(message, toplevel_enums, generate_types:) }.join
+        body += file.message_type.map { |message| MessageCompiler.result(message, toplevel_enums, generate_types:, requires:) }.join
+
+        head += requires.map { |r| "require #{r.dump}" }.join("\n") + "\n\n"
+        head += modules.map { |m| "module #{m}\n" }.join
 
         tail = "\n" + modules.map { "end" }.join("\n")
 

--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -1344,7 +1344,7 @@ module ProtoBoeuf
       @generate_types = generate_types
     end
 
-    def to_ruby
+    def to_ruby(this_file = nil)
       requires = Set.new
       @ast.file.each do |file|
         modules = resolve_modules(file)
@@ -1356,7 +1356,7 @@ module ProtoBoeuf
         body = file.enum_type.map { |enum| EnumCompiler.result(enum, generate_types:) }.join + "\n"
         body += file.message_type.map { |message| MessageCompiler.result(message, toplevel_enums, generate_types:, requires:) }.join
 
-        head += requires.map { |r| "require #{r.dump}" }.join("\n") + "\n\n"
+        head += requires.reject { |r| r == this_file }.map { |r| "require #{r.dump}" }.join("\n") + "\n\n"
         head += modules.map { |m| "module #{m}\n" }.join
 
         tail = "\n" + modules.map { "end" }.join("\n")


### PR DESCRIPTION
- **Use protoc to generate our well known types**
- **Put all the requires at the top of generated code**
- **Don't print a require for the file we are generating**

This works around a bug in our parser regarding circular top-level message defs.