### PR TITLE
Fix the class name for fields imported from protoc

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -544,8 +544,15 @@ module ProtoBoeuf
           }.join("\n") + "\n"
       end
 
+      # Translate ".package.name::NestedMessage" into "Package::Name::NestedMessage".
       def class_name(type)
-        translate_well_known(type).delete_prefix(".").gsub(".", "::")
+        translate_well_known(type).delete_prefix(".").split(/\.|::/).map do |part|
+          part.split("_").map do |s|
+            # We need to "constantize" the fields that don't look like constants
+            # but if they already do we don't want to break the casing.
+            s.match?(/^[A-Z]/) ? s : s.capitalize
+          end.join("")
+        end.join("::")
       end
 
       def required_readers

--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -540,12 +540,12 @@ module ProtoBoeuf
 
         "  # enum readers\n" +
           fields.map { |field|
-            "def #{field.name}; #{class_name(field)}.lookup(#{iv_name(field)}) || #{iv_name(field)}; end"
+            "def #{field.name}; #{class_name(field.type_name)}.lookup(#{iv_name(field)}) || #{iv_name(field)}; end"
           }.join("\n") + "\n"
       end
 
-      def class_name(field)
-        translate_well_known(field.type_name).delete_prefix(".").gsub(".", "::")
+      def class_name(type)
+        translate_well_known(type).delete_prefix(".").gsub(".", "::")
       end
 
       def required_readers
@@ -599,7 +599,7 @@ module ProtoBoeuf
 
         "# enum writers\n" +
           fields.map { |field|
-            "def #{field.name}=(v); #{iv_name(field)} = #{class_name(field)}.resolve(v) || v; end"
+            "def #{field.name}=(v); #{iv_name(field)} = #{class_name(field.type_name)}.resolve(v) || v; end"
           }.join("\n") + "\n\n"
       end
 
@@ -756,7 +756,7 @@ module ProtoBoeuf
       end
 
       def initialize_enum_field(field)
-        "#{iv_name(field)} = #{class_name(field)}.resolve(#{field.name}) || #{lvar_read(field)}"
+        "#{iv_name(field)} = #{class_name(field.type_name)}.resolve(#{field.name}) || #{lvar_read(field)}"
       end
 
       def extra_api
@@ -1345,7 +1345,7 @@ module ProtoBoeuf
         <<~RUBY
           ## PULL_MESSAGE
           #{pull_uint64("msg_len", "=")}
-          #{dest} #{operator} #{type}.allocate.decode_from(buff, index, index += msg_len)
+          #{dest} #{operator} #{class_name(type)}.allocate.decode_from(buff, index, index += msg_len)
           ## END PULL_MESSAGE
         RUBY
       end

--- a/test/fixtures/package_test.proto
+++ b/test/fixtures/package_test.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package package_test.proto3;
+
+message Test1 {
+  message SubMsg {
+    int32 a = 1;
+  }
+}


### PR DESCRIPTION
- **Fix class name for type when pulling message**
- **Fix the class name for fields imported from protoc**

In the conformance tests we're getting code that looks like
```ruby
protobuf_test_messages.editions::TestAllTypesEdition2023::NestedEnum.lookup(
```

This fixes the class name to
```ruby
ProtobufTestMessages::Editions::TestAllTypesEdition2023::NestedEnum.lookup(
```