### PR TITLE
Enums with underscores should keep the underscore

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -593,18 +593,27 @@ module ProtoBoeuf
 
         "  # enum readers\n" +
           fields.map { |field|
-            "def #{field.name}; #{class_name(field.type_name)}.lookup(#{iv_name(field)}) || #{iv_name(field)}; end"
+            "def #{field.name}; #{enum_name(field)}.lookup(#{iv_name(field)}) || #{iv_name(field)}; end"
           }.join("\n") + "\n"
+      end
+
+      def enum_name(field)
+        raise ArgumentError unless field.type == :TYPE_ENUM
+        class_name(field.type_name)
       end
 
       # Translate ".package.name::NestedMessage" into "Package::Name::NestedMessage".
       def class_name(type)
         translate_well_known(type).delete_prefix(".").split(/\.|::/).map do |part|
-          part.split("_").map do |s|
-            # We need to "constantize" the fields that don't look like constants
-            # but if they already do we don't want to break the casing.
-            s.match?(/^[A-Z]/) ? s : s.capitalize
-          end.join("")
+          if part =~ /^[A-Z]/
+            part
+          else
+            part.split("_").map do |s|
+              # We need to "constantize" the fields that don't look like constants
+              # but if they already do we don't want to break the casing.
+              s.match?(/^[A-Z]/) ? s : s.capitalize
+            end.join
+          end
         end.join("::")
       end
 
@@ -659,7 +668,7 @@ module ProtoBoeuf
 
         "# enum writers\n" +
           fields.map { |field|
-            "def #{field.name}=(v); #{iv_name(field)} = #{class_name(field.type_name)}.resolve(v) || v; end"
+            "def #{field.name}=(v); #{iv_name(field)} = #{enum_name(field)}.resolve(v) || v; end"
           }.join("\n") + "\n\n"
       end
 
@@ -816,7 +825,7 @@ module ProtoBoeuf
       end
 
       def initialize_enum_field(field)
-        "#{iv_name(field)} = #{class_name(field.type_name)}.resolve(#{field.name}) || #{lvar_read(field)}"
+        "#{iv_name(field)} = #{enum_name(field)}.resolve(#{field.name}) || #{lvar_read(field)}"
       end
 
       def extra_api

--- a/lib/protoboeuf/protobuf/descriptor.rb
+++ b/lib/protoboeuf/protobuf/descriptor.rb
@@ -1599,14 +1599,14 @@ module ProtoBoeuf
         list = @public_dependency
         if list.size > 0
           buff << 0x52
-          len = list.size
-          while len != 0
-            byte = len & 0x7F
-            len >>= 7
-            byte |= 0x80 if len > 0
-            buff << byte
-          end
 
+          # Save the buffer size before appending the repeated bytes
+          current_len = buff.bytesize
+
+          # Write a single dummy byte to later store encoded length
+          buff << 42 # "*"
+
+          # write each item
           list.each do |item|
             val = item
             if val != 0
@@ -1624,19 +1624,53 @@ module ProtoBoeuf
               end
             end
           end
+
+          # Calculate the submessage's size
+          submessage_size = buff.bytesize - current_len - 1
+
+          # Hope the size fits in one byte
+          byte = submessage_size & 0x7F
+          submessage_size >>= 7
+          byte |= 0x80 if submessage_size > 0
+          buff.setbyte(current_len, byte)
+
+          # If the sub message was bigger
+          if submessage_size > 0
+            current_len += 1
+
+            # compute how much we need to shift
+            encoded_int_len = 0
+            remaining_size = submessage_size
+            while remaining_size != 0
+              remaining_size >>= 7
+              encoded_int_len += 1
+            end
+
+            # Make space in the string with dummy bytes
+            buff.bytesplice(current_len, 0, "*********", 0, encoded_int_len)
+
+            # Overwrite the dummy bytes with the encoded length
+            while submessage_size != 0
+              byte = submessage_size & 0x7F
+              submessage_size >>= 7
+              byte |= 0x80 if submessage_size > 0
+              buff.setbyte(current_len, byte)
+              current_len += 1
+            end
+          end
         end
 
         list = @weak_dependency
         if list.size > 0
           buff << 0x5a
-          len = list.size
-          while len != 0
-            byte = len & 0x7F
-            len >>= 7
-            byte |= 0x80 if len > 0
-            buff << byte
-          end
 
+          # Save the buffer size before appending the repeated bytes
+          current_len = buff.bytesize
+
+          # Write a single dummy byte to later store encoded length
+          buff << 42 # "*"
+
+          # write each item
           list.each do |item|
             val = item
             if val != 0
@@ -1652,6 +1686,40 @@ module ProtoBoeuf
                 byte |= 0x80 if val != 0
                 buff << byte
               end
+            end
+          end
+
+          # Calculate the submessage's size
+          submessage_size = buff.bytesize - current_len - 1
+
+          # Hope the size fits in one byte
+          byte = submessage_size & 0x7F
+          submessage_size >>= 7
+          byte |= 0x80 if submessage_size > 0
+          buff.setbyte(current_len, byte)
+
+          # If the sub message was bigger
+          if submessage_size > 0
+            current_len += 1
+
+            # compute how much we need to shift
+            encoded_int_len = 0
+            remaining_size = submessage_size
+            while remaining_size != 0
+              remaining_size >>= 7
+              encoded_int_len += 1
+            end
+
+            # Make space in the string with dummy bytes
+            buff.bytesplice(current_len, 0, "*********", 0, encoded_int_len)
+
+            # Overwrite the dummy bytes with the encoded length
+            while submessage_size != 0
+              byte = submessage_size & 0x7F
+              submessage_size >>= 7
+              byte |= 0x80 if submessage_size > 0
+              buff.setbyte(current_len, byte)
+              current_len += 1
             end
           end
         end
@@ -18460,14 +18528,14 @@ module ProtoBoeuf
           list = @path
           if list.size > 0
             buff << 0x0a
-            len = list.size
-            while len != 0
-              byte = len & 0x7F
-              len >>= 7
-              byte |= 0x80 if len > 0
-              buff << byte
-            end
 
+            # Save the buffer size before appending the repeated bytes
+            current_len = buff.bytesize
+
+            # Write a single dummy byte to later store encoded length
+            buff << 42 # "*"
+
+            # write each item
             list.each do |item|
               val = item
               if val != 0
@@ -18485,19 +18553,53 @@ module ProtoBoeuf
                 end
               end
             end
+
+            # Calculate the submessage's size
+            submessage_size = buff.bytesize - current_len - 1
+
+            # Hope the size fits in one byte
+            byte = submessage_size & 0x7F
+            submessage_size >>= 7
+            byte |= 0x80 if submessage_size > 0
+            buff.setbyte(current_len, byte)
+
+            # If the sub message was bigger
+            if submessage_size > 0
+              current_len += 1
+
+              # compute how much we need to shift
+              encoded_int_len = 0
+              remaining_size = submessage_size
+              while remaining_size != 0
+                remaining_size >>= 7
+                encoded_int_len += 1
+              end
+
+              # Make space in the string with dummy bytes
+              buff.bytesplice(current_len, 0, "*********", 0, encoded_int_len)
+
+              # Overwrite the dummy bytes with the encoded length
+              while submessage_size != 0
+                byte = submessage_size & 0x7F
+                submessage_size >>= 7
+                byte |= 0x80 if submessage_size > 0
+                buff.setbyte(current_len, byte)
+                current_len += 1
+              end
+            end
           end
 
           list = @span
           if list.size > 0
             buff << 0x12
-            len = list.size
-            while len != 0
-              byte = len & 0x7F
-              len >>= 7
-              byte |= 0x80 if len > 0
-              buff << byte
-            end
 
+            # Save the buffer size before appending the repeated bytes
+            current_len = buff.bytesize
+
+            # Write a single dummy byte to later store encoded length
+            buff << 42 # "*"
+
+            # write each item
             list.each do |item|
               val = item
               if val != 0
@@ -18513,6 +18615,40 @@ module ProtoBoeuf
                   byte |= 0x80 if val != 0
                   buff << byte
                 end
+              end
+            end
+
+            # Calculate the submessage's size
+            submessage_size = buff.bytesize - current_len - 1
+
+            # Hope the size fits in one byte
+            byte = submessage_size & 0x7F
+            submessage_size >>= 7
+            byte |= 0x80 if submessage_size > 0
+            buff.setbyte(current_len, byte)
+
+            # If the sub message was bigger
+            if submessage_size > 0
+              current_len += 1
+
+              # compute how much we need to shift
+              encoded_int_len = 0
+              remaining_size = submessage_size
+              while remaining_size != 0
+                remaining_size >>= 7
+                encoded_int_len += 1
+              end
+
+              # Make space in the string with dummy bytes
+              buff.bytesplice(current_len, 0, "*********", 0, encoded_int_len)
+
+              # Overwrite the dummy bytes with the encoded length
+              while submessage_size != 0
+                byte = submessage_size & 0x7F
+                submessage_size >>= 7
+                byte |= 0x80 if submessage_size > 0
+                buff.setbyte(current_len, byte)
+                current_len += 1
               end
             end
           end
@@ -19342,14 +19478,14 @@ module ProtoBoeuf
           list = @path
           if list.size > 0
             buff << 0x0a
-            len = list.size
-            while len != 0
-              byte = len & 0x7F
-              len >>= 7
-              byte |= 0x80 if len > 0
-              buff << byte
-            end
 
+            # Save the buffer size before appending the repeated bytes
+            current_len = buff.bytesize
+
+            # Write a single dummy byte to later store encoded length
+            buff << 42 # "*"
+
+            # write each item
             list.each do |item|
               val = item
               if val != 0
@@ -19365,6 +19501,40 @@ module ProtoBoeuf
                   byte |= 0x80 if val != 0
                   buff << byte
                 end
+              end
+            end
+
+            # Calculate the submessage's size
+            submessage_size = buff.bytesize - current_len - 1
+
+            # Hope the size fits in one byte
+            byte = submessage_size & 0x7F
+            submessage_size >>= 7
+            byte |= 0x80 if submessage_size > 0
+            buff.setbyte(current_len, byte)
+
+            # If the sub message was bigger
+            if submessage_size > 0
+              current_len += 1
+
+              # compute how much we need to shift
+              encoded_int_len = 0
+              remaining_size = submessage_size
+              while remaining_size != 0
+                remaining_size >>= 7
+                encoded_int_len += 1
+              end
+
+              # Make space in the string with dummy bytes
+              buff.bytesplice(current_len, 0, "*********", 0, encoded_int_len)
+
+              # Overwrite the dummy bytes with the encoded length
+              while submessage_size != 0
+                byte = submessage_size & 0x7F
+                submessage_size >>= 7
+                byte |= 0x80 if submessage_size > 0
+                buff.setbyte(current_len, byte)
+                current_len += 1
               end
             end
           end

--- a/test/codegen_test.rb
+++ b/test/codegen_test.rb
@@ -5,6 +5,30 @@ require_relative "./fixtures/package_test_pb.rb"
 
 module ProtoBoeuf
   class CodeGenTest < Test
+    def test_enum_with_underscore
+      unit = parse_string(<<-EOPROTO)
+syntax = "proto3";
+
+message Vehicle
+{
+  enum VEHICLE_TYPE {
+    CAR = 0;
+    SPORTS_CAR = 1;
+  }
+
+  VEHICLE_TYPE type = 6;
+}
+      EOPROTO
+
+      gen = CodeGen.new unit
+      klass = Class.new { self.class_eval gen.to_ruby }
+
+      msg = klass::Vehicle.new
+      assert_equal :CAR, msg.type
+      msg.type = :SPORTS_CAR
+      assert_equal :SPORTS_CAR, msg.type
+    end
+
     def test_uppercase_field_name
       unit = parse_string(<<-EOPROTO)
 syntax = "proto3";


### PR DESCRIPTION
We were removing underscores from enum names when we generate the class name. This restores the underscores (but only for enums)