### PR TITLE
Convert benchmark code to use new AST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [ head, '3.2', '3.3' ]
+        ruby: [ head, '3.3' ]
         ruby-opt: [""]
         include:
           - ruby: "3.3"

--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,7 @@ file BENCHMARK_PROTOBOEUF_PB => ["bench/fixtures/benchmark.proto"] + codegen_rb_
   codegen_rb_files.each { |f| require_relative f }
 
   unit = ProtoBoeuf.parse_file t.source
-  unit.package = "proto_boeuf"
+  unit.file.each { |f| f.package = "proto_boeuf" }
   gen = ProtoBoeuf::CodeGen.new unit
 
   File.binwrite t.name, gen.to_ruby


### PR DESCRIPTION
This converts the benchmark code to use the new AST format, also fixing the benchmarks.

`rake bench` works now:

```
###### YJIT ######
/Users/aaron/.rubies/arm64/ruby-master/bin/ruby --yjit -I lib:bench/lib bench/benchmark.rb
total encoded size: 4715043 bytes
=== decode ===
ruby 3.4.0dev (2024-08-21T16:07:28Z master 53e3795379) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        upstream/jit    12.000 i/100ms
      protoboeuf/jit     5.000 i/100ms
Calculating -------------------------------------
        upstream/jit    120.726 (± 1.7%) i/s -    612.000 in   5.070227s
      protoboeuf/jit     58.245 (± 0.0%) i/s -    295.000 in   5.065063s

Comparison:
     upstream/interp:      120.6 i/s
        upstream/jit:      120.7 i/s - same-ish: difference falls within error
      protoboeuf/jit:       58.2 i/s - 2.07x  slower
   protoboeuf/interp:       11.9 i/s - 10.13x  slower

=== decode and read ===
ruby 3.4.0dev (2024-08-21T16:07:28Z master 53e3795379) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        upstream/jit     1.000 i/100ms
      protoboeuf/jit     5.000 i/100ms
Calculating -------------------------------------
        upstream/jit      8.865 (± 0.0%) i/s -     45.000 in   5.077033s
      protoboeuf/jit     53.439 (± 0.0%) i/s -    270.000 in   5.052790s

Comparison:
     upstream/interp:        7.9 i/s
      protoboeuf/jit:       53.4 i/s - 6.79x  faster
   protoboeuf/interp:       10.1 i/s - 1.28x  faster
        upstream/jit:        8.9 i/s - 1.13x  faster

=== encode ===
ruby 3.4.0dev (2024-08-21T16:07:28Z master 53e3795379) +YJIT [arm64-darwin23]
Warming up --------------------------------------
        upstream/jit    12.000 i/100ms
      protoboeuf/jit     5.000 i/100ms
Calculating -------------------------------------
        upstream/jit    121.316 (± 1.6%) i/s -    612.000 in   5.046227s
      protoboeuf/jit     53.623 (± 7.5%) i/s -    270.000 in   5.065559s

Comparison:
     upstream/interp:      134.6 i/s
        upstream/jit:      121.3 i/s - 1.11x  slower
      protoboeuf/jit:       53.6 i/s - 2.51x  slower
   protoboeuf/interp:       11.4 i/s - 11.80x  slower

```