### PR TITLE
Encode enums as int32 since they can be negative

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -246,17 +246,6 @@ module ProtoBoeuf
         RUBY
       end
 
-      def encode_enum(field, value_expr, tagged)
-        # Zero is default value for enums, so encodes nothing
-        <<~RUBY
-          val = #{value_expr}
-          if val != 0
-            #{encode_tag_and_length(field, tagged)}
-            #{uint64_code("val")}
-          end
-        RUBY
-      end
-
       def encode_map(field, value_expr, tagged)
         map_type = self.map_type(field)
 
@@ -465,6 +454,9 @@ module ProtoBoeuf
 
       # The same encoding logic is used for int32 and int64
       alias encode_int32 encode_int64
+
+      # Bools and enums are both encoded as if they were int32s
+      alias encode_enum encode_int32
 
       def encode_sint64(field, value_expr, tagged)
         # Zero is the default value, so it encodes zero bytes

--- a/lib/protoboeuf/protobuf/descriptor.rb
+++ b/lib/protoboeuf/protobuf/descriptor.rb
@@ -2051,8 +2051,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -5149,8 +5155,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -6266,8 +6278,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -6278,8 +6296,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -10419,8 +10443,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -11447,8 +11477,14 @@ module ProtoBoeuf
 
             while val != 0
               byte = val & 0x7F
+
               val >>= 7
-              byte |= 0x80 if val > 0
+              # This drops the top bits,
+              # Otherwise, with a signed right shift,
+              # we get infinity one bits at the top
+              val &= (1 << 57) - 1
+
+              byte |= 0x80 if val != 0
               buff << byte
             end
           end
@@ -11865,8 +11901,14 @@ module ProtoBoeuf
 
             while val != 0
               byte = val & 0x7F
+
               val >>= 7
-              byte |= 0x80 if val > 0
+              # This drops the top bits,
+              # Otherwise, with a signed right shift,
+              # we get infinity one bits at the top
+              val &= (1 << 57) - 1
+
+              byte |= 0x80 if val != 0
               buff << byte
             end
           end
@@ -11877,8 +11919,14 @@ module ProtoBoeuf
 
             while val != 0
               byte = val & 0x7F
+
               val >>= 7
-              byte |= 0x80 if val > 0
+              # This drops the top bits,
+              # Otherwise, with a signed right shift,
+              # we get infinity one bits at the top
+              val &= (1 << 57) - 1
+
+              byte |= 0x80 if val != 0
               buff << byte
             end
           end
@@ -11902,8 +11950,14 @@ module ProtoBoeuf
 
             while val != 0
               byte = val & 0x7F
+
               val >>= 7
-              byte |= 0x80 if val > 0
+              # This drops the top bits,
+              # Otherwise, with a signed right shift,
+              # we get infinity one bits at the top
+              val &= (1 << 57) - 1
+
+              byte |= 0x80 if val != 0
               buff << byte
             end
           end
@@ -12960,8 +13014,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -12983,8 +13043,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -13050,8 +13116,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -13065,8 +13137,14 @@ module ProtoBoeuf
 
               while val != 0
                 byte = val & 0x7F
+
                 val >>= 7
-                byte |= 0x80 if val > 0
+                # This drops the top bits,
+                # Otherwise, with a signed right shift,
+                # we get infinity one bits at the top
+                val &= (1 << 57) - 1
+
+                byte |= 0x80 if val != 0
                 buff << byte
               end
             end
@@ -15314,8 +15392,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17042,8 +17126,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17054,8 +17144,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17066,8 +17162,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17078,8 +17180,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17090,8 +17198,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17102,8 +17216,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17433,8 +17553,14 @@ module ProtoBoeuf
 
             while val != 0
               byte = val & 0x7F
+
               val >>= 7
-              byte |= 0x80 if val > 0
+              # This drops the top bits,
+              # Otherwise, with a signed right shift,
+              # we get infinity one bits at the top
+              val &= (1 << 57) - 1
+
+              byte |= 0x80 if val != 0
               buff << byte
             end
           end
@@ -17885,8 +18011,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -17897,8 +18029,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end
@@ -19594,8 +19732,14 @@ module ProtoBoeuf
 
             while val != 0
               byte = val & 0x7F
+
               val >>= 7
-              byte |= 0x80 if val > 0
+              # This drops the top bits,
+              # Otherwise, with a signed right shift,
+              # we get infinity one bits at the top
+              val &= (1 << 57) - 1
+
+              byte |= 0x80 if val != 0
               buff << byte
             end
           end

--- a/lib/protoboeuf/protobuf/struct.rb
+++ b/lib/protoboeuf/protobuf/struct.rb
@@ -776,8 +776,14 @@ module ProtoBoeuf
 
           while val != 0
             byte = val & 0x7F
+
             val >>= 7
-            byte |= 0x80 if val > 0
+            # This drops the top bits,
+            # Otherwise, with a signed right shift,
+            # we get infinity one bits at the top
+            val &= (1 << 57) - 1
+
+            byte |= 0x80 if val != 0
             buff << byte
           end
         end

--- a/test/codegen_test.rb
+++ b/test/codegen_test.rb
@@ -207,6 +207,28 @@ message Test1 {
       assert_equal :BAR, msg.enum_1
     end
 
+    def test_neg_enum
+      unit = parse_string(<<-EOPROTO)
+syntax = "proto3";
+
+enum TestEnum {
+  FOO = 0;
+  BAR = 1;
+  BAZ = -1;
+}
+
+message Test1 {
+  TestEnum enum_1 = 1;
+}
+      EOPROTO
+      gen = CodeGen.new unit
+      klass = Class.new { self.class_eval gen.to_ruby }
+
+      msg = klass::Test1.new(enum_1: :BAZ)
+      msg = klass::Test1.decode(klass::Test1.encode(msg))
+      assert_equal :BAZ, msg.enum_1
+    end
+
     def test_required_field
       unit = parse_string(<<-EOPROTO)
 message Test1 {

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -912,8 +912,14 @@ class Test1
 
       while val != 0
         byte = val & 0x7F
+
         val >>= 7
-        byte |= 0x80 if val > 0
+        # This drops the top bits,
+        # Otherwise, with a signed right shift,
+        # we get infinity one bits at the top
+        val &= (1 << 57) - 1
+
+        byte |= 0x80 if val != 0
         buff << byte
       end
     end
@@ -924,8 +930,14 @@ class Test1
 
       while val != 0
         byte = val & 0x7F
+
         val >>= 7
-        byte |= 0x80 if val > 0
+        # This drops the top bits,
+        # Otherwise, with a signed right shift,
+        # we get infinity one bits at the top
+        val &= (1 << 57) - 1
+
+        byte |= 0x80 if val != 0
         buff << byte
       end
     end


### PR DESCRIPTION
https://protobuf.dev/programming-guides/encoding/#bools-and-enums:~:text=Bools%20and%20enums%20are%20both%20encoded%20as%20if%20they%20were%20int32s
