### PR TITLE
Disable all RuboCop rules for generated files

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -1577,8 +1577,10 @@ module ProtoBoeuf
       @ast.file.each do |file|
         modules = resolve_modules(file)
         head = "# encoding: ascii-8bit\n"
+        head += "# rubocop:disable all\n"
         head += "# typed: false\n" if generate_types
-        head += "# frozen_string_literal: true\n\n"
+        head += "# frozen_string_literal: true\n"
+        head += "\n"
 
         toplevel_enums = file.enum_type.group_by(&:name)
         body = file.enum_type.map { |enum| EnumCompiler.result(enum, generate_types:) }.join + "\n"

--- a/lib/protoboeuf/protobuf/any.rb
+++ b/lib/protoboeuf/protobuf/any.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/boolvalue.rb
+++ b/lib/protoboeuf/protobuf/boolvalue.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/bytesvalue.rb
+++ b/lib/protoboeuf/protobuf/bytesvalue.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/descriptor.rb
+++ b/lib/protoboeuf/protobuf/descriptor.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/doublevalue.rb
+++ b/lib/protoboeuf/protobuf/doublevalue.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/duration.rb
+++ b/lib/protoboeuf/protobuf/duration.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/field_mask.rb
+++ b/lib/protoboeuf/protobuf/field_mask.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/floatvalue.rb
+++ b/lib/protoboeuf/protobuf/floatvalue.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/int32value.rb
+++ b/lib/protoboeuf/protobuf/int32value.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/int64value.rb
+++ b/lib/protoboeuf/protobuf/int64value.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/stringvalue.rb
+++ b/lib/protoboeuf/protobuf/stringvalue.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/struct.rb
+++ b/lib/protoboeuf/protobuf/struct.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/timestamp.rb
+++ b/lib/protoboeuf/protobuf/timestamp.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/uint32value.rb
+++ b/lib/protoboeuf/protobuf/uint32value.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/lib/protoboeuf/protobuf/uint64value.rb
+++ b/lib/protoboeuf/protobuf/uint64value.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # frozen_string_literal: true
 
 module ProtoBoeuf

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# rubocop:disable all
 # typed: false
 # frozen_string_literal: true
 


### PR DESCRIPTION
Fixes #143 

We don't want RuboCop to autocorrect generated files, as they are generated by protoboeuf and should not be modified by hand. Any modifications by RuboCop could even lead to performance issues since some code is generated in a way that is not idiomatic Ruby, but is optimized for performance, especially with YJIT.