### PR TITLE
Remove artificial limit on optional field count

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -1564,7 +1564,6 @@ module ProtoBoeuf
 
       def init_bitmask(msg)
         optionals = optional_fields
-        raise NotImplementedError if optionals.length >= 63
 
         if optionals.empty?
           ""

--- a/test/codegen_test.rb
+++ b/test/codegen_test.rb
@@ -228,6 +228,24 @@ module ProtoBoeuf
       assert(Class.new { class_eval(gen.to_ruby) })
     end
 
+    def test_many_optional_fields
+      unit = parse_string(<<~EOPROTO)
+        syntax = "proto3";
+
+        message TestManyOptionalFields {
+          #{(1..99).map { |i| "optional int32 a#{i} = #{i};" }.join("\n")}
+        }
+      EOPROTO
+      gen = CodeGen.new(unit)
+      klass = Class.new { class_eval(gen.to_ruby) }
+
+      msg = klass::TestManyOptionalFields.new(a59: 0, a60: 1, a99: 1)
+      msg = klass::TestManyOptionalFields.decode(klass::TestManyOptionalFields.encode(msg))
+      refute_predicate(msg, :has_a59?)
+      assert_predicate(msg, :has_a60?)
+      assert_predicate(msg, :has_a99?)
+    end
+
     def test_enum_field
       unit = parse_string(<<~EOPROTO)
         syntax = "proto3";


### PR DESCRIPTION
The limit was 62.
The conformance suite needs 63.
If we want to keep the mask as a simple fixnum in ruby it would need to be 61.

This is the code being generated now, the `field_name17` is number 62 (you can see how the bitmask gets longer):

```
def has_field__name15?
  (@_bitmask & 0x4000000000000000) == 0x4000000000000000
end

def has_field__Name16?
  (@_bitmask & 0x8000000000000000) == 0x8000000000000000
end

def has_field_name17__?
  (@_bitmask & 0x10000000000000000) == 0x10000000000000000
end
```

Looking at it through ruby's eyes:

```
irb /main:036:0:> sprintf "%16x", Fiddle.dlwrap(1 << 60)
 => "2000000000000001"
irb /main:037:0:> sprintf "%16x", Fiddle.dlwrap(1 << 61)
 => "4000000000000001"
irb /main:038:0:> sprintf "%16x", Fiddle.dlwrap(1 << 62)
 => "    7f0e32c2a280"
irb /main:039:0:> sprintf "%16x", Fiddle.dlwrap(1 << 63)
 => "    7f0e32af3740"
```