### PR TITLE
Define to_proto method for encoding a message instance

### DIFF
--- a/lib/protoboeuf/codegen.rb
+++ b/lib/protoboeuf/codegen.rb
@@ -872,7 +872,14 @@ module ProtoBoeuf
       end
 
       def extra_api
-        optional_predicates
+        <<~RUBY
+          #{type_signature(params: { _options: "T::Hash" }, returns: "String")}
+          def to_proto(_options = {})
+            self.class.encode(self)
+          end
+
+          #{optional_predicates}
+        RUBY
       end
 
       def optional_predicates

--- a/test/codegen_test.rb
+++ b/test/codegen_test.rb
@@ -511,6 +511,23 @@ module ProtoBoeuf
       refute(gen.to_ruby(path).to_s.match?(require_line), "require should not be present")
     end
 
+    def test_to_proto
+      unit = parse_string(<<~PROTO)
+        syntax = "proto3";
+
+        message Foo {
+          int32 a = 1;
+        }
+      PROTO
+
+      gen = CodeGen.new(unit)
+      klass = Class.new { class_eval gen.to_ruby }
+      obj = klass::Foo.new(a: 255)
+
+      assert_equal(255, obj.a)
+      assert_equal("\x08\xff\x01".b, obj.to_proto)
+    end
+
     def test_bounds_checks
       proto = <<~PROTO
         message Test1 {

--- a/test/fixtures/typed_test.correct.rb
+++ b/test/fixtures/typed_test.correct.rb
@@ -209,6 +209,11 @@ class Test1
     @bytes_field = bytes_field
   end
 
+  sig { params(_options: T::Hash).returns(String) }
+  def to_proto(_options = {})
+    self.class.encode(self)
+  end
+
   sig { returns(T::Boolean) }
   def has_string_field?
     (@_bitmask & 0x0000000000000001) == 0x0000000000000001


### PR DESCRIPTION
The conformance suite uses this.