### PR TITLE
Ensure codegen pull requests include generated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,11 @@ jobs:
       - name: Run RuboCop
         run: bundle exec rubocop
 
+      - name: Ensure generated files are up to date
+        # On a clean checkout the timestamps may not trigger the well_known_types to regenerate.
+        run: |
+          bundle exec rake RUBYOPT="${{ matrix.rubyopt }}" clobber well_known_types
+          git diff --exit-code
+
       - name: Run tests ${{ matrix.rubyopt }}
         run: bundle exec rake RUBYOPT="${{ matrix.rubyopt }}"


### PR DESCRIPTION
Force files to regenerate in CI and ensure there are no uncommitted changes.

See example failed job at https://github.com/rwstauner/protoboeuf/actions/runs/10531333771/job/29183160776#step:7:635

refs #151 