### PR TITLE
Use `String#append_as_bytes` if available

### DIFF
--- a/bench/benchmark.rb
+++ b/bench/benchmark.rb
@@ -32,7 +32,7 @@ def gen_fake_field_val(type_map, field)
     rand < 0.5
   when :TYPE_STRING
     # TODO: better random strings with variable lengths
-    "foobar" + "_foo" * rand(0..8)
+    "foobar€" + "_foo" * rand(0..8)
   when :TYPE_UINT64, :TYPE_INT32, :TYPE_SINT32, :TYPE_UINT32, :TYPE_INT64,
             :TYPE_SINT64, :TYPE_FIXED64, :TYPE_FIXED32, :TYPE_SFIXED32,
             :TYPE_SFIXED64, :TYPE_ENUM
@@ -174,10 +174,17 @@ Benchmark.ips do |x|
 end
 
 puts "=== encode ==="
+before_gc = GC.count
 Benchmark.ips do |x|
-  x.report("upstream#{version}") { fake_msgs.each { |msg| Upstream::ParkingLot.encode(msg) } }
-  x.report("protoboeuf#{version}") { decoded_msgs_proto.each { |msg| ProtoBoeuf::ParkingLot.encode(msg) } }
+  # Call String#clear to appease GC. Each iteration generated ~5MiB of strings. Every ~30MiB malloced
+  # GC triggers, so by clearing these strings we reduce GC triggers, reducing variance.
+  # On my machine adding these clear reduce GC triggers from 445 to 248.
+
+  x.report("upstream#{version}") { fake_msgs.each { |msg| Upstream::ParkingLot.encode(msg).clear } }
+  x.report("protoboeuf#{version}") { decoded_msgs_proto.each { |msg| ProtoBoeuf::ParkingLot.encode(msg).clear } }
 
   x.save!(File.join(ENV["BENCH_HOLD"], "encode.bench")) if ENV["BENCH_HOLD"]
   x.compare!(order: :baseline)
 end
+
+puts "Encode GC count: #{GC.count - before_gc}"


### PR DESCRIPTION
Final version of: https://github.com/Shopify/protoboeuf/pull/116
Ref: https://bugs.ruby-lang.org/issues/20594

This isn't yet as fast as the prototype because the final method was merged as `append_as_bytes` with variadic and Integer support so I haven't implemented a YJIT acceleration yet.

But since we can now consider the interface stable, we can merge.