### PR TITLE
Add test for parsing circular references

### DIFF
--- a/test/parser_compatibility_test.rb
+++ b/test/parser_compatibility_test.rb
@@ -343,6 +343,25 @@ module ProtoBoeuf
       )
     end
 
+    def test_circular_messages
+      ours, theirs = parse_string(<<-EOPROTO)
+syntax = "proto3";
+
+message Circular {
+  CircularValue circ = 1;
+}
+
+message CircularValue {
+  oneof kind {
+    Circular circ = 1;
+    CircularValue val = 2;
+  }
+}
+      EOPROTO
+
+      assert_same_tree theirs, ours
+    end
+
     def test_fixture_file
       ours, theirs = parse_string(File.binread("./test/fixtures/test.proto"))
       assert_same_tree(theirs, ours)


### PR DESCRIPTION
Currently fails with:

```
  1) Failure:
ProtoBoeuf::ParserCompatibilityTest#test_circular_messages [test/parser_compatibility_test.rb:362]:
Expected: ".CircularValue"
  Actual: ".Circular.CircularValue"

  2) Failure:
ProtoBoeuf::ASTCompatibility#test_circular_messages [test/parser_compatibility_test.rb:362]:
Expected: ".CircularValue"
  Actual: ".Circular.CircularValue"
```